### PR TITLE
[fix] 폰트 에러 문제 해결

### DIFF
--- a/src/styles/fontStyle.ts
+++ b/src/styles/fontStyle.ts
@@ -8,8 +8,8 @@ const fontStyle = css`
     font-weight: 600;
     font-display: swap;
     src: local('Pretendard SemiBold'),
-      url('./fonts/Pretendard-SemiBold.woff2') format('woff2'),
-      url('./fonts/Pretendard-SemiBold.woff') format('woff');
+      local('./fonts/Pretendard-SemiBold.woff2') format('woff2'),
+      local('./fonts/Pretendard-SemiBold.woff') format('woff');
   }
 
   @font-face {
@@ -17,8 +17,8 @@ const fontStyle = css`
     font-weight: 500;
     font-display: swap;
     src: local('Pretendard Medium'),
-      url('./fonts/Pretendard-Medium.woff2') format('woff2'),
-      url('./fonts/Pretendard-Medium.woff') format('woff');
+      local('./fonts/Pretendard-Medium.woff2') format('woff2'),
+      local('./fonts/Pretendard-Medium.woff') format('woff');
   }
 
   @font-face {
@@ -26,8 +26,8 @@ const fontStyle = css`
     font-weight: 400;
     font-display: swap;
     src: local('Pretendard Regular'),
-      url('./fonts/Pretendard-Regular.woff2') format('woff2'),
-      url('./fonts/Pretendard-Regular.woff') format('woff');
+      local('./fonts/Pretendard-Regular.woff2') format('woff2'),
+      local('./fonts/Pretendard-Regular.woff') format('woff');
   }
 
   @font-face {

--- a/src/styles/reset.ts
+++ b/src/styles/reset.ts
@@ -1,6 +1,10 @@
 import { css } from '@emotion/react';
 
 const reset = css`
+  * {
+    font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui,
+      'Noto Sans KR', 'Malgun Gothic', sans-serif;
+  }
   html,
   body,
   div,
@@ -88,7 +92,8 @@ const reset = css`
     font-size: 100%;
     font: inherit;
     vertical-align: baseline;
-    font-family: 'Roboto', sans-serif;
+    font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui,
+      'Noto Sans KR', 'Malgun Gothic', sans-serif;
   }
   /* HTML5 display-role reset for older browsers */
   article,


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
Pretendard 폰트가 적용되지 않는 오류를 해결했습니다.
- 파일을 로컬로 담고 있음에도 폰트 내의 @font-face 의 src에 `url`을 사용했던 것이 문제였습니다. 
- 해당 부분을 `local` 로 변경하면 해결된다는 @Outwater 님의 조언을 받아 수월히 해결했습니다!
 
reset.css의 기본 글씨체를 Pretendard로 바꿔 두었습니다.
-  Pretendard, Maplestory 2개의 체만 사용하는데 roboto보다는 둘 중 하나를 기본 폰트로 두는게 맞다고 생각했습니다.
-  둘 중 가독성이 좋은 Pretendard로 일단 바꿔두었습니다.

## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
[7efb4fe](https://github.com/prgrms-fe-devcourse/FEDC2_CheQuiz_Gidong/commit/7efb4fe6a3e6dc8eafd638c680a1605fc9fb5478)
- 프리텐다드 font-face 관련 변경 및 reset.css 글꼴 변경
## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
close #31