### PR TITLE
[Feat] 퀴즈, 댓글 조회를 위한 탭 컴포넌트 구현

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -35,3 +35,16 @@ export const fetchUserQuiz = async (userId: string) => {
     throw new Error('Get UserQuiz Failed');
   }
 };
+
+// 임시로 사용 => 추후 준혁님의 quizService merge시 해당 API 사용 예정
+export const fetchPosts = async () => {
+  try {
+    const res = await axiosInstance({
+      method: 'GET',
+      url: `/posts`,
+    });
+    return res.data;
+  } catch (error) {
+    throw new Error('Get Posts Failed');
+  }
+};

--- a/src/components/Header/styles.tsx
+++ b/src/components/Header/styles.tsx
@@ -8,6 +8,7 @@ export const HeaderContainer = styled.div`
   width: 100%;
   border-bottom: 3px solid #343a40;
   background-color: #f8f9fa;
+  z-index: 3;
 `;
 
 // header : fixed에 의한 레이아웃 용

--- a/src/components/UserInfo/UserInfoTab/index.tsx
+++ b/src/components/UserInfo/UserInfoTab/index.tsx
@@ -1,11 +1,57 @@
+import { useEffect, useState } from 'react';
+import { fetchPosts } from '@/api/user';
 import * as S from './styles';
+import { PostAPIUserInfo } from '@/interfaces/PostAPI';
+import { UserQuizType } from '@/interfaces/UserAPI';
 
 function UserInfoTab({ id }: { id: string }) {
+  const [madeQuizzes, setMadeQuizzes] = useState([]);
+  const [commentedQuizzes, setCommentedQuizzes] = useState([]);
+  const [likedQuizzes, setLikedQuizzes] = useState([]);
+
+  useEffect(() => {
+    const updateAllQuiz = async () => {
+      const apiData = await fetchPosts();
+      const realData = apiData.map((post: PostAPIUserInfo) => ({
+        id: post._id,
+        likes: post.likes,
+        comments: post.comments,
+        author: post.author,
+        ...JSON.parse(post.title),
+      }));
+
+      const userMadeQuizzes = realData.filter(
+        (quiz: UserQuizType) => quiz.author._id === id,
+      );
+
+      const userCommentQuizzes = realData.filter((quiz: UserQuizType) => {
+        const userCommentIndex = quiz.comments.findIndex((comment) => {
+          return comment.author._id === id;
+        });
+        const isUserComment = userCommentIndex !== -1;
+        return isUserComment;
+      });
+
+      const userLikesQuizzes = realData.filter((quiz: UserQuizType) => {
+        const userLikesIndex = quiz.likes.findIndex((like) => {
+          return like.user === id;
+        });
+        const isUserLiked = userLikesIndex !== -1;
+        return isUserLiked;
+      });
+
+      setMadeQuizzes(userMadeQuizzes);
+      setCommentedQuizzes(userCommentQuizzes);
+      setLikedQuizzes(userLikesQuizzes);
+    };
+
+    updateAllQuiz();
+  }, [id]);
   return (
     <S.TabWrapper>
       <S.TabItemContainer>
         <S.TabItem selected>만든 문제</S.TabItem>
-        <S.TabItem>댓글</S.TabItem>
+        <S.TabItem>댓글 단 문제</S.TabItem>
         <S.TabItem>좋아요 한 문제</S.TabItem>
       </S.TabItemContainer>
 

--- a/src/components/UserInfo/UserInfoTab/index.tsx
+++ b/src/components/UserInfo/UserInfoTab/index.tsx
@@ -4,11 +4,31 @@ import * as S from './styles';
 import { PostAPIUserInfo } from '@/interfaces/PostAPI';
 import { UserQuizType } from '@/interfaces/UserAPI';
 import UserQuizItem from '../UserQuizItem';
+import TabItem from '../UserInfoTabItem';
 
 function UserInfoTab({ id }: { id: string }) {
   const [madeQuizzes, setMadeQuizzes] = useState([]);
   const [commentedQuizzes, setCommentedQuizzes] = useState([]);
   const [likedQuizzes, setLikedQuizzes] = useState([]);
+
+  const [currentTab, setCurrentTab] = useState(0);
+
+  const tabMapper = [madeQuizzes, commentedQuizzes, likedQuizzes];
+
+  const tabs = [
+    {
+      id: 0,
+      title: '만든 문제',
+    },
+    {
+      id: 1,
+      title: '댓글 단 문제',
+    },
+    {
+      id: 2,
+      title: '좋아요 한 문제',
+    },
+  ];
 
   useEffect(() => {
     const updateAllQuiz = async () => {
@@ -44,18 +64,28 @@ function UserInfoTab({ id }: { id: string }) {
       setMadeQuizzes(userMadeQuizzes);
       setCommentedQuizzes(userCommentQuizzes);
       setLikedQuizzes(userLikesQuizzes);
-      console.log(userMadeQuizzes);
     };
 
     updateAllQuiz();
   }, [id]);
+
+  const updateClickedTab = (tabId: number) => {
+    setCurrentTab(tabId);
+  };
   return (
     <S.TabWrapper>
       <S.TabMenus>
         <S.TabItemContainer>
-          <S.TabItem selected>만든 문제</S.TabItem>
-          <S.TabItem>댓글 단 문제</S.TabItem>
-          <S.TabItem>좋아요 한 문제</S.TabItem>
+          {tabs.map((tab) => (
+            <TabItem
+              key={tab.id}
+              title={tab.title}
+              selected={tab.id === currentTab}
+              handleClick={() => {
+                updateClickedTab(tab.id);
+              }}
+            />
+          ))}
         </S.TabItemContainer>
         <S.ButtonWrapper>
           <S.Button color="#5B9785">퀴즈 수정</S.Button>
@@ -65,7 +95,7 @@ function UserInfoTab({ id }: { id: string }) {
 
       <S.TabContent>
         <S.UserQuizContainer>
-          {madeQuizzes.map((quiz: UserQuizType, index) => (
+          {tabMapper[currentTab].map((quiz: UserQuizType) => (
             <UserQuizItem
               key={quiz.id}
               question={quiz.question}
@@ -73,52 +103,6 @@ function UserInfoTab({ id }: { id: string }) {
               commentCount={quiz.comments.length}
             />
           ))}
-          {/* TODO: 데이터가 충분히 많아지면 지우기 ( 스크롤 테스트용) */}
-          <UserQuizItem
-            question="자바스크립트는 싱글스레드로 동작한다"
-            likeCount={3}
-            commentCount={122}
-          />
-          <UserQuizItem
-            question="자바스크립트는 싱글스레드로 동작한다"
-            likeCount={3}
-            commentCount={122}
-          />{' '}
-          <UserQuizItem
-            question="자바스크립트는 싱글스레드로 동작한다"
-            likeCount={3}
-            commentCount={122}
-          />{' '}
-          <UserQuizItem
-            question="자바스크립트는 싱글스레드로 동작한다"
-            likeCount={3}
-            commentCount={122}
-          />{' '}
-          <UserQuizItem
-            question="자바스크립트는 싱글스레드로 동작한다"
-            likeCount={3}
-            commentCount={122}
-          />{' '}
-          <UserQuizItem
-            question="자바스크립트는 싱글스레드로 동작한다"
-            likeCount={3}
-            commentCount={122}
-          />{' '}
-          <UserQuizItem
-            question="자바스크립트는 싱글스레드로 동작한다"
-            likeCount={3}
-            commentCount={122}
-          />{' '}
-          <UserQuizItem
-            question="자바스크립트는 싱글스레드로 동작한다"
-            likeCount={3}
-            commentCount={122}
-          />{' '}
-          <UserQuizItem
-            question="자바스크립트는 싱글스레드로 동작한다"
-            likeCount={3}
-            commentCount={122}
-          />
         </S.UserQuizContainer>
       </S.TabContent>
     </S.TabWrapper>

--- a/src/components/UserInfo/UserInfoTab/index.tsx
+++ b/src/components/UserInfo/UserInfoTab/index.tsx
@@ -1,0 +1,22 @@
+import * as S from './styles';
+
+function UserInfoTab({ id }: { id: string }) {
+  return (
+    <S.TabWrapper>
+      <S.TabItemContainer>
+        <S.TabItem selected>만든 문제</S.TabItem>
+        <S.TabItem>댓글</S.TabItem>
+        <S.TabItem>좋아요 한 문제</S.TabItem>
+      </S.TabItemContainer>
+
+      <S.TabContent>
+        <S.ButtonWrapper>
+          <S.Button color="#5B9785">퀴즈 수정</S.Button>
+          <S.Button color="#CE4C4C">퀴즈 삭제</S.Button>
+        </S.ButtonWrapper>
+      </S.TabContent>
+    </S.TabWrapper>
+  );
+}
+
+export default UserInfoTab;

--- a/src/components/UserInfo/UserInfoTab/index.tsx
+++ b/src/components/UserInfo/UserInfoTab/index.tsx
@@ -3,6 +3,7 @@ import { fetchPosts } from '@/api/user';
 import * as S from './styles';
 import { PostAPIUserInfo } from '@/interfaces/PostAPI';
 import { UserQuizType } from '@/interfaces/UserAPI';
+import UserQuizItem from '../UserQuizItem';
 
 function UserInfoTab({ id }: { id: string }) {
   const [madeQuizzes, setMadeQuizzes] = useState([]);
@@ -43,23 +44,82 @@ function UserInfoTab({ id }: { id: string }) {
       setMadeQuizzes(userMadeQuizzes);
       setCommentedQuizzes(userCommentQuizzes);
       setLikedQuizzes(userLikesQuizzes);
+      console.log(userMadeQuizzes);
     };
 
     updateAllQuiz();
   }, [id]);
   return (
     <S.TabWrapper>
-      <S.TabItemContainer>
-        <S.TabItem selected>만든 문제</S.TabItem>
-        <S.TabItem>댓글 단 문제</S.TabItem>
-        <S.TabItem>좋아요 한 문제</S.TabItem>
-      </S.TabItemContainer>
-
-      <S.TabContent>
+      <S.TabMenus>
+        <S.TabItemContainer>
+          <S.TabItem selected>만든 문제</S.TabItem>
+          <S.TabItem>댓글 단 문제</S.TabItem>
+          <S.TabItem>좋아요 한 문제</S.TabItem>
+        </S.TabItemContainer>
         <S.ButtonWrapper>
           <S.Button color="#5B9785">퀴즈 수정</S.Button>
           <S.Button color="#CE4C4C">퀴즈 삭제</S.Button>
         </S.ButtonWrapper>
+      </S.TabMenus>
+
+      <S.TabContent>
+        <S.UserQuizContainer>
+          {madeQuizzes.map((quiz: UserQuizType, index) => (
+            <UserQuizItem
+              key={quiz.id}
+              question={quiz.question}
+              likeCount={quiz.likes.length}
+              commentCount={quiz.comments.length}
+            />
+          ))}
+          {/* TODO: 데이터가 충분히 많아지면 지우기 ( 스크롤 테스트용) */}
+          <UserQuizItem
+            question="자바스크립트는 싱글스레드로 동작한다"
+            likeCount={3}
+            commentCount={122}
+          />
+          <UserQuizItem
+            question="자바스크립트는 싱글스레드로 동작한다"
+            likeCount={3}
+            commentCount={122}
+          />{' '}
+          <UserQuizItem
+            question="자바스크립트는 싱글스레드로 동작한다"
+            likeCount={3}
+            commentCount={122}
+          />{' '}
+          <UserQuizItem
+            question="자바스크립트는 싱글스레드로 동작한다"
+            likeCount={3}
+            commentCount={122}
+          />{' '}
+          <UserQuizItem
+            question="자바스크립트는 싱글스레드로 동작한다"
+            likeCount={3}
+            commentCount={122}
+          />{' '}
+          <UserQuizItem
+            question="자바스크립트는 싱글스레드로 동작한다"
+            likeCount={3}
+            commentCount={122}
+          />{' '}
+          <UserQuizItem
+            question="자바스크립트는 싱글스레드로 동작한다"
+            likeCount={3}
+            commentCount={122}
+          />{' '}
+          <UserQuizItem
+            question="자바스크립트는 싱글스레드로 동작한다"
+            likeCount={3}
+            commentCount={122}
+          />{' '}
+          <UserQuizItem
+            question="자바스크립트는 싱글스레드로 동작한다"
+            likeCount={3}
+            commentCount={122}
+          />
+        </S.UserQuizContainer>
       </S.TabContent>
     </S.TabWrapper>
   );

--- a/src/components/UserInfo/UserInfoTab/index.tsx
+++ b/src/components/UserInfo/UserInfoTab/index.tsx
@@ -46,21 +46,11 @@ function UserInfoTab({ id }: { id: string }) {
       );
 
       const userCommentQuizzes = realData.filter((quiz: UserQuizType) => {
-        const userCommentIndex = quiz.comments.findIndex((comment) => {
-          return comment.author._id === id;
-        });
-        const isUserComment = userCommentIndex !== -1;
-        return isUserComment;
+        return quiz.comments.some((comment) => comment.author._id === id);
       });
-
       const userLikesQuizzes = realData.filter((quiz: UserQuizType) => {
-        const userLikesIndex = quiz.likes.findIndex((like) => {
-          return like.user === id;
-        });
-        const isUserLiked = userLikesIndex !== -1;
-        return isUserLiked;
+        return quiz.likes.some((like) => like.user === id);
       });
-
       setMadeQuizzes(userMadeQuizzes);
       setCommentedQuizzes(userCommentQuizzes);
       setLikedQuizzes(userLikesQuizzes);

--- a/src/components/UserInfo/UserInfoTab/styles.tsx
+++ b/src/components/UserInfo/UserInfoTab/styles.tsx
@@ -9,6 +9,7 @@ export const TabWrapper = styled.div`
 export const TabContent = styled.div`
   position: relative;
   height: 28rem;
+  padding: 1rem;
   background-color: #f8f9fa;
   border: 3px solid #343a40;
   border-radius: 8px;
@@ -43,7 +44,7 @@ export const TabItem = styled.div<tabItemProps>`
 
 export const ButtonWrapper = styled.div`
   display: inline-flex;
-  margin: 2rem 1rem;
+  margin: 2rem 0rem;
   background-color: aliceblue;
   gap: 0.5rem;
 `;
@@ -67,4 +68,10 @@ export const Button = styled.button<buttonProps>`
   &:hover {
     filter: brightness(120%);
   }
+`;
+
+export const UserQuizContainer = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 1rem;
 `;

--- a/src/components/UserInfo/UserInfoTab/styles.tsx
+++ b/src/components/UserInfo/UserInfoTab/styles.tsx
@@ -1,0 +1,70 @@
+import styled from '@emotion/styled';
+
+export const TabWrapper = styled.div`
+  margin-top: 4rem;
+  width: 100%;
+  min-width: 40rem;
+`;
+
+export const TabContent = styled.div`
+  position: relative;
+  height: 28rem;
+  background-color: #f8f9fa;
+  border: 3px solid #343a40;
+  border-radius: 8px;
+`;
+
+export const TabItemContainer = styled.div`
+  position: relative;
+  top: 0.3rem;
+`;
+
+type tabItemProps = {
+  selected?: boolean;
+};
+
+export const TabItem = styled.div<tabItemProps>`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 10rem;
+  height: 3rem;
+  margin-right: 0.5rem;
+  border: 3px solid #343a40;
+  border-radius: 8px;
+  color: ${({ selected }) => (selected ? '#f8f9fa' : 'black')};
+  background-color: ${({ selected }) => (selected ? `#14213D` : `white`)};
+  font-family: 'MaplestoryOTFLight', sans-serif;
+  cursor: pointer;
+  &:hover {
+    background-color: ${({ selected }) => (selected ? '#14213D' : '#E9ECEF')};
+  }
+`;
+
+export const ButtonWrapper = styled.div`
+  display: inline-flex;
+  margin: 2rem 1rem;
+  background-color: aliceblue;
+  gap: 0.5rem;
+`;
+
+type buttonProps = {
+  color?: string;
+  selected?: boolean;
+};
+export const Button = styled.button<buttonProps>`
+  border: 3px solid #343a40;
+  border-radius: 8px;
+  width: 9rem;
+  height: 2.5rem;
+  font-size: 1rem;
+  font-family: 'MaplestoryOTFLight', sans-serif;
+  background-color: ${({ color }) => color};
+  color: white;
+  cursor: pointer;
+  filter: ${({ selected }) => (selected ? `brightness(120%)` : null)};
+
+  &:hover {
+    filter: brightness(120%);
+  }
+`;

--- a/src/components/UserInfo/UserInfoTab/styles.tsx
+++ b/src/components/UserInfo/UserInfoTab/styles.tsx
@@ -1,9 +1,15 @@
 import styled from '@emotion/styled';
+import { lightGrayWhite, primary } from '@/styles/theme';
 
 export const TabWrapper = styled.div`
   margin-top: 4rem;
   width: 100%;
   min-width: 40rem;
+`;
+
+export const TabMenus = styled.div`
+  display: flex;
+  justify-content: space-between;
 `;
 
 export const TabContent = styled.div`
@@ -13,6 +19,17 @@ export const TabContent = styled.div`
   background-color: #f8f9fa;
   border: 3px solid #343a40;
   border-radius: 8px;
+  overflow: auto;
+
+  &::-webkit-scrollbar {
+    width: 0.5rem;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: ${primary};
+  }
+  &::-webkit-scrollbar-track {
+    background-color: ${lightGrayWhite};
+  }
 `;
 
 export const TabItemContainer = styled.div`
@@ -44,7 +61,6 @@ export const TabItem = styled.div<tabItemProps>`
 
 export const ButtonWrapper = styled.div`
   display: inline-flex;
-  margin: 2rem 0rem;
   background-color: aliceblue;
   gap: 0.5rem;
 `;

--- a/src/components/UserInfo/UserInfoTab/styles.tsx
+++ b/src/components/UserInfo/UserInfoTab/styles.tsx
@@ -4,7 +4,7 @@ import { lightGrayWhite, primary } from '@/styles/theme';
 export const TabWrapper = styled.div`
   margin-top: 4rem;
   width: 100%;
-  min-width: 40rem;
+  min-width: 20rem;
 `;
 
 export const TabMenus = styled.div`
@@ -61,7 +61,6 @@ export const TabItem = styled.div<tabItemProps>`
 
 export const ButtonWrapper = styled.div`
   display: inline-flex;
-  background-color: aliceblue;
   gap: 0.5rem;
 `;
 

--- a/src/components/UserInfo/UserInfoTabItem/index.tsx
+++ b/src/components/UserInfo/UserInfoTabItem/index.tsx
@@ -1,0 +1,16 @@
+import * as S from './styles';
+
+interface TabItemProps {
+  title: string;
+  selected: boolean;
+  handleClick?: (e: React.MouseEvent) => void;
+}
+function TabItem({ title, selected, handleClick }: TabItemProps) {
+  return (
+    <S.TabItemWrapper selected={selected} onClick={handleClick}>
+      {title}
+    </S.TabItemWrapper>
+  );
+}
+
+export default TabItem;

--- a/src/components/UserInfo/UserInfoTabItem/styles.tsx
+++ b/src/components/UserInfo/UserInfoTabItem/styles.tsx
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+
+type tabItemProps = {
+  selected?: boolean;
+};
+
+export const TabItemWrapper = styled.button<tabItemProps>`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 10rem;
+  height: 3rem;
+  margin-right: 0.5rem;
+  border: 3px solid #343a40;
+  border-radius: 8px;
+  color: ${({ selected }) => (selected ? '#f8f9fa' : 'black')};
+  background-color: ${({ selected }) => (selected ? `#14213D` : `white`)};
+  font-family: 'MaplestoryOTFLight', sans-serif;
+  cursor: pointer;
+  &:hover {
+    background-color: ${({ selected }) => (selected ? '#14213D' : '#E9ECEF')};
+  }
+`;

--- a/src/components/UserInfo/UserQuizItem/index.tsx
+++ b/src/components/UserInfo/UserQuizItem/index.tsx
@@ -7,16 +7,8 @@ interface QuizItemProps {
   commentCount: number;
 }
 
-const likeIconProps = {
-  name: 'thumbs-up',
-  size: 20,
-  strokeWidth: 2,
-  color: '#343A40',
-  rotate: 0,
-};
-
-const commentIconProps = {
-  name: 'message-square',
+const IconProps = {
+  name: '',
   size: 20,
   strokeWidth: 2,
   color: '#343A40',
@@ -39,11 +31,11 @@ function UserQuizItem({ question, likeCount, commentCount }: QuizItemProps) {
 
       <S.CountWrapper>
         <S.CountItem>
-          <Icon {...likeIconProps} />
+          <Icon {...IconProps} name="thumbs-up" />
           {renderCount(likeCount, 100)}
         </S.CountItem>
         <S.CountItem>
-          <Icon {...commentIconProps} />
+          <Icon {...IconProps} name="message-square" />
           {renderCount(commentCount, 100)}
         </S.CountItem>
       </S.CountWrapper>

--- a/src/components/UserInfo/UserQuizItem/index.tsx
+++ b/src/components/UserInfo/UserQuizItem/index.tsx
@@ -1,0 +1,48 @@
+import Icon from '@/components/Icon';
+import * as S from './styles';
+
+interface QuizItemProps {
+  question: string;
+  likeCount: number;
+  commentCount: number;
+}
+
+const likeIconProps = {
+  name: 'thumbs-up',
+  size: 20,
+  strokeWidth: 2,
+  color: '#343A40',
+  rotate: 0,
+};
+
+const commentIconProps = {
+  name: 'message-square',
+  size: 20,
+  strokeWidth: 2,
+  color: '#343A40',
+  rotate: 0,
+};
+
+function UserQuizItem({ question, likeCount, commentCount }: QuizItemProps) {
+  return (
+    <S.ItemWrapper>
+      <S.ContentWrapper>
+        <S.QuestionSymbol>Q.</S.QuestionSymbol>
+        <S.QuestionText>{question}</S.QuestionText>
+      </S.ContentWrapper>
+
+      <S.CountWrapper>
+        <S.CountItem>
+          <Icon {...likeIconProps} />
+          {likeCount}
+        </S.CountItem>
+        <S.CountItem>
+          <Icon {...commentIconProps} />
+          {commentCount}
+        </S.CountItem>
+      </S.CountWrapper>
+    </S.ItemWrapper>
+  );
+}
+
+export default UserQuizItem;

--- a/src/components/UserInfo/UserQuizItem/index.tsx
+++ b/src/components/UserInfo/UserQuizItem/index.tsx
@@ -24,6 +24,12 @@ const commentIconProps = {
 };
 
 function UserQuizItem({ question, likeCount, commentCount }: QuizItemProps) {
+  const renderCount = (currentCount: number, maxCount: number) => {
+    if (currentCount > maxCount) {
+      return `${maxCount}+`;
+    }
+    return `${currentCount}`;
+  };
   return (
     <S.ItemWrapper>
       <S.ContentWrapper>
@@ -34,11 +40,11 @@ function UserQuizItem({ question, likeCount, commentCount }: QuizItemProps) {
       <S.CountWrapper>
         <S.CountItem>
           <Icon {...likeIconProps} />
-          {likeCount}
+          {renderCount(likeCount, 100)}
         </S.CountItem>
         <S.CountItem>
           <Icon {...commentIconProps} />
-          {commentCount}
+          {renderCount(commentCount, 100)}
         </S.CountItem>
       </S.CountWrapper>
     </S.ItemWrapper>

--- a/src/components/UserInfo/UserQuizItem/styles.tsx
+++ b/src/components/UserInfo/UserQuizItem/styles.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+import { borderRadius, large, primary, small } from '@/styles/theme';
+
+export const ItemWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  height: 5.5rem;
+  border: 3px solid ${primary};
+  border-radius: ${borderRadius};
+  //width: 35rem;
+  overflow: hidden;
+  cursor: pointer;
+  transition: all 0.1s;
+  //TODO: hover 호불호 의견 구해보기
+  &:hover {
+    box-shadow: 2px 2px 0px 2px ${primary};
+    transform: translateY(-5%);
+  }
+`;
+
+export const ContentWrapper = styled.div`
+  flex: 1;
+  display: flex;
+  padding: 1rem;
+  height: 4.5rem;
+`;
+export const QuestionSymbol = styled.span`
+  ${large};
+  position: relative;
+  bottom: 0.25rem;
+  margin-right: 0.25rem;
+`;
+export const QuestionText = styled.h3`
+  font-family: 'Pretendard', sans-serif;
+  ${small};
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 25rem;
+`;
+
+export const CountWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  width: 5rem;
+  height: 100%;
+  padding: 1rem;
+  background-color: #ffdc84;
+`;
+export const CountItem = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 0.25rem;
+  color: ${primary};
+`;

--- a/src/components/UserInfo/UserQuizItem/styles.tsx
+++ b/src/components/UserInfo/UserQuizItem/styles.tsx
@@ -4,10 +4,11 @@ import { borderRadius, large, primary, small } from '@/styles/theme';
 export const ItemWrapper = styled.div`
   display: flex;
   align-items: center;
+  //width: 35rem;
   height: 5.5rem;
   border: 3px solid ${primary};
   border-radius: ${borderRadius};
-  //width: 35rem;
+  background-color: white;
   overflow: hidden;
   cursor: pointer;
   transition: all 0.1s;
@@ -54,7 +55,8 @@ export const CountWrapper = styled.div`
 export const CountItem = styled.div`
   display: flex;
   justify-content: flex-start;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.25rem;
+  width: 100%;
   color: ${primary};
 `;

--- a/src/components/UserInfo/UserQuizItem/styles.tsx
+++ b/src/components/UserInfo/UserQuizItem/styles.tsx
@@ -49,7 +49,7 @@ export const CountWrapper = styled.div`
   align-items: center;
   width: 5rem;
   height: 100%;
-  padding: 1rem;
+  padding: 0.8rem;
   background-color: #ffdc84;
 `;
 export const CountItem = styled.div`

--- a/src/interfaces/Quiz.d.ts
+++ b/src/interfaces/Quiz.d.ts
@@ -13,4 +13,12 @@ export interface QuizContent {
 export interface QuizClientContent extends QuizContent {
   _id: number;
 }
+
 export interface Quiz extends PostAPIBase, QuizContent {}
+
+export interface QuizShowContent extends QuizContent {
+  _id: number;
+  likes: LikeAPI[];
+  comments: CommentAPI[];
+  author: UserAPI;
+}

--- a/src/interfaces/UserAPI.d.ts
+++ b/src/interfaces/UserAPI.d.ts
@@ -67,3 +67,17 @@ export interface userQuizCategory {
   id: string;
   category: string;
 }
+
+export interface UserQuizType {
+  id: string;
+  question: string;
+  answer: string;
+  answerDescription: string;
+  answerType: 'trueOrFalse' | 'multipleChoice' | 'shortAnswer';
+  author: UserAPI;
+  category: string;
+  difficulty: number;
+  importance: number;
+  comments: CommentAPI[];
+  likes: LikeAPI[];
+}

--- a/src/pages/UserInfo.tsx
+++ b/src/pages/UserInfo.tsx
@@ -1,11 +1,13 @@
 import Header from '@/components/Header';
 import UserInfoCard from '@/components/UserInfo/UserInfoCard';
+import UserInfoTab from '@/components/UserInfo/UserInfoTab';
 
 function UserInfo() {
   return (
     <div>
       <Header />
       <UserInfoCard id="62aafe7ce193b3692eddfc77" />
+      <UserInfoTab id="62aafe7ce193b3692eddfc77" />
     </div>
   );
 }


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 사용자가 만든, 댓글을 단, 좋아요를 누른 퀴즈를 볼 수 있는 탭 컴포넌트를 구현했습니다.
- GET /posts API를 사용해서 연동했습니다.

### 테스트 방법
`localhost:3000/user`에서 확인 ( '미해' 캐릭터의 정보를 조회합니다)
- 추가 테스트 : `pages/UserInfo.tsx` 파일의 <UserInfoTab/> 에 id를 조회를 원하는 유저의 아이디로 바꿔주면 관련된 데이터가 뜨는 것을 보실 수 있습니다.

### 로직 설명
GET /posts 로 모든 포스트를 가져오고 퀴즈로 변환한 뒤
-  현재 유저가 만든 퀴즈 / 댓글을 단 퀴즈 / 좋아요를 누른 퀴즈  
  
로 필터링하여 해당 값들을 state로 저장합니다.
눌린 탭의 정보를 저장해서, 해당 탭에 속한 퀴즈를 보여줍니다.

* 참고 : 퀴즈 수정, 삭제는 버튼만 만들어 놓은 상태이며, 추후 PR에서 시, '만든 문제' 탭에서만 활성화 되도록 변경할 예정입니다.
### 변경 사항
 feature 산출 시에는,`작성한 댓글` 을 보여주기로 하였으나, `내가 댓글을 단 문제` 로 변경하였습니다.
댓글만 보여주면 어떤 문제인지 파악하기 어렵다는 생각을 하였고, 차라리 내가 댓글 단 글을 보여주고, 글을 클릭 시 내가 단 댓글을 확인할 수 있게 하는 것이 낫다고 판단했습니다. 에브리타임 등 해당 방식으로 사용하는 SNS가 많이 존재한다는 것을 파악하였고, 해당  방식으로 진행하려고 합니다. 혹시 이 변경사항 관련해서 이견이 있으시면 댓글에 적어주세요!

### 미리 보기
![탭구현](https://user-images.githubusercontent.com/39826053/174469942-99e44a12-5a1a-43f0-acc4-9ac34a46ecd3.gif)
- 위 gif에는 예외처리를 보여주기 위해 긴 퀴즈 dummy data가 포함되어 있습니다.
  
## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
`UserInfo/UserInfoTab`
- 전체적인 탭 컴포넌트를 구성했습니다.
- 여러 조건으로 sort된 퀴즈 배열들을 state로 담고, 보여줍니다.

`UserInfo/UserInfoTabItem`
- 선택된 여부에 따라 배경 색이 바뀌는 탭의 클릭하는 부분을 분리했습니다.

`UserInfo/UserQuizItem`
- 탭 내부에 들어가는 Quiz의 모습을 나타내는 컴포넌트입니다. 
- 추후, id도 props로 받아 클릭 시 세부 내용이 뜨게 변경될 가능성이 있습니다.
   
## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
-  디자인 선호 관련 : 문제를  hover하면 키보드 자판이 위로 올라오는 듯한 효과를 추가했습니다. 이런 효과를 넣어도 괜찮은가요? ( 빼는게 좋다는 의견 있다면 말씀해주세요)
close #61