### PR TITLE
[Feat] QuizResultPage api 연결

### DIFF
--- a/src/api/UserServices.ts
+++ b/src/api/UserServices.ts
@@ -3,8 +3,14 @@ import api from '@/api/apiInstance';
 import { CommentAPI } from '@/interfaces/CommentAPI';
 import { LikeAPI } from '@/interfaces/LikeAPI';
 
+const token = localStorage.getItem('token');
+
+const isNotNull = (item: string | null): item is string => {
+  return !!item;
+};
+
 const headers: AxiosRequestHeaders = {
-  Authorization: `Bearer ${JSON.parse(localStorage.getItem('token') || '')}`,
+  Authorization: `Bearer ${isNotNull(token) ? JSON.parse(token) : ''}`,
 };
 
 export function like(postId: string) {

--- a/src/api/UserServices.ts
+++ b/src/api/UserServices.ts
@@ -3,15 +3,16 @@ import api from '@/api/apiInstance';
 import { CommentAPI } from '@/interfaces/CommentAPI';
 import { LikeAPI } from '@/interfaces/LikeAPI';
 
-const token = localStorage.getItem('token');
-
 const isNotNull = (item: string | null): item is string => {
   return !!item;
 };
 
-const headers: AxiosRequestHeaders = {
-  Authorization: `Bearer ${isNotNull(token) ? JSON.parse(token) : ''}`,
-};
+function getHeaders(): AxiosRequestHeaders {
+  const token = localStorage.getItem('token');
+  return {
+    Authorization: `Bearer ${isNotNull(token) ? JSON.parse(token) : ''}`,
+  };
+}
 
 export function like(postId: string) {
   return api
@@ -19,7 +20,7 @@ export function like(postId: string) {
       '/likes/create',
       { postId },
       {
-        headers: { ...headers },
+        headers: { ...getHeaders() },
       },
     )
     .then((response) => response.data)
@@ -29,7 +30,10 @@ export function like(postId: string) {
 }
 
 export function cancelLike(likeId: string) {
-  return api.delete('/likes/delete', { data: { id: likeId }, headers });
+  return api.delete('/likes/delete', {
+    data: { id: likeId },
+    headers: { ...getHeaders() },
+  });
 }
 
 export function createComment({
@@ -44,7 +48,7 @@ export function createComment({
       '/comments/create',
       { comment, postId },
       {
-        headers: { ...headers },
+        headers: { ...getHeaders() },
       },
     )
     .then((response) => response.data)
@@ -55,5 +59,8 @@ export function createComment({
 }
 
 export function deleteComment(commentId: string) {
-  return api.delete('/comments/delete', { data: { id: commentId }, headers });
+  return api.delete('/comments/delete', {
+    data: { id: commentId },
+    headers: { ...getHeaders() },
+  });
 }

--- a/src/components/QuizResult/index.tsx
+++ b/src/components/QuizResult/index.tsx
@@ -54,6 +54,7 @@ function QuizResult({ quiz, correct }: QuizResultProps) {
       setComments((prev) => [...prev, newComment]);
       setInputValue('');
     } catch (error) {
+      console.log(error);
       window.alert('문제가 생겨 댓글을 작성할 수 없습니다.');
       throw new Error('error occured at postComment.');
     }

--- a/src/components/QuizResult/index.tsx
+++ b/src/components/QuizResult/index.tsx
@@ -23,12 +23,21 @@ function QuizResult({ quiz, correct }: QuizResultProps) {
   );
   // TODO: useCollapse 만들기
   const [collapsed, setCollapsed] = useState(true);
-  const handleCommentSubmit = (e: React.FormEvent) => {
+  const handleCommentSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: comment validation
-    UserService.createComment({ comment: inputValue, postId: quiz._id });
+
+    // TODO: alert를 toast로 변경
+    if (!inputValue.trim()) alert('1글자 이상 작성해야 합니다.');
+
+    const newComment = await UserService.createComment({
+      comment: inputValue,
+      postId: quiz._id,
+    });
+    console.log(newComment);
     setInputValue('');
   };
+
+  const isLoggedIn = !(JSON.stringify(user) === '{}' || !user);
 
   return (
     <S.Box>
@@ -64,7 +73,15 @@ function QuizResult({ quiz, correct }: QuizResultProps) {
               <S.Flex>
                 <S.ProfileImage>작성자 사진</S.ProfileImage>
                 <S.InputWrapper>
-                  <S.Input type="text" value={inputValue} onChange={handler} />
+                  <S.Input
+                    type="text"
+                    value={inputValue}
+                    onChange={handler}
+                    placeholder={
+                      isLoggedIn ? '댓글을 남겨보세요.' : '로그인해야 합니다.'
+                    }
+                    disabled={!isLoggedIn}
+                  />
                 </S.InputWrapper>
 
                 {/** TODO: disabled when loading */}

--- a/src/components/QuizResult/index.tsx
+++ b/src/components/QuizResult/index.tsx
@@ -43,7 +43,7 @@ function QuizResult({ quiz, correct }: QuizResultProps) {
             Toggle
           </button>
           <button type="button">좋아요 {quiz.likes.length}</button>
-          <button type="button">댓글</button>
+          <button type="button">댓글 {comments.length}</button>
         </S.HeaderRight>
       </S.Header>
       <AnimateHeight duration={350} height={collapsed ? 0 : 'auto'}>
@@ -70,7 +70,7 @@ function QuizResult({ quiz, correct }: QuizResultProps) {
               </S.Flex>
             </form>
           </S.Wrapper>
-          <h1>comment 보기</h1>
+          <h1>{comments.length ? '코멘트 보기' : '코멘트가 없습니다.'}</h1>
           {comments.map((comment) => (
             <S.Comment key={comment._id}>
               <S.ProfileImage>작성자 사진</S.ProfileImage>

--- a/src/components/QuizResult/index.tsx
+++ b/src/components/QuizResult/index.tsx
@@ -3,6 +3,7 @@ import useInput from '@hooks/useInput';
 import AnimateHeight from 'react-animate-height';
 import { Quiz } from '@/interfaces/Quiz';
 import { CommentAPI } from '@/interfaces/CommentAPI';
+import { useAuthContext } from '@/contexts/AuthContext';
 import * as UserService from '@/utils/UserServices';
 import * as S from './styles';
 
@@ -11,12 +12,15 @@ interface QuizResultProps extends S.StyledQuizResultProps {
 }
 
 function QuizResult({ quiz, correct }: QuizResultProps) {
+  const { user } = useAuthContext();
   const [inputValue, handler, setInputValue] = useInput('');
   const [comments, setComments] = useState<CommentAPI[]>(() =>
     quiz && quiz.comments ? quiz.comments : [],
   );
-  // TODO: useState에 들어갈 값 변경 필요 -> quiz likes 배열 참조할 것
-  const [userLiked, setUserLiked] = useState(false);
+  // TODO: TEST 필요
+  const [userLiked, setUserLiked] = useState(
+    () => user._id && quiz.likes.map((like) => like.user).includes(user._id),
+  );
   // TODO: useCollapse 만들기
   const [collapsed, setCollapsed] = useState(true);
   const handleCommentSubmit = (e: React.FormEvent) => {

--- a/src/components/QuizResult/styles.tsx
+++ b/src/components/QuizResult/styles.tsx
@@ -3,10 +3,7 @@ import styled from '@emotion/styled';
 // TODO: 임시 prop 바꾸기
 interface StyledButtonProps {
   color?: 'point' | 'primary' | 'secondary';
-}
-
-interface CollapsedProps {
-  collapsed: boolean;
+  fullWidth?: boolean;
 }
 
 interface StyledSignProps {
@@ -36,7 +33,7 @@ export const Container = styled.div`
   margin: 0 1rem;
 `;
 
-export const Header = styled.div<CollapsedProps>`
+export const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -175,5 +172,9 @@ export const Button = styled.button<StyledButtonProps>`
   :hover {
     // TODO: 각 color 마다 추가 작업 필요
     background-color: #fca211d9;
+  }
+
+  :disabled {
+    cursor: default;
   }
 `;

--- a/src/contexts/AuthContext/index.tsx
+++ b/src/contexts/AuthContext/index.tsx
@@ -6,8 +6,10 @@ import { LoginFormData } from '@/interfaces/LoginFormData';
 import { SignUpFormData } from '@/interfaces/SignUpFormData';
 
 import auth from '@/api/auth';
+import { UserAPI } from '@/interfaces/UserAPI';
 
 interface AuthContextType {
+  user: Partial<UserAPI>;
   token: string;
   login: (formData: LoginFormData) => void;
   signUp: (formData: SignUpFormData) => void;
@@ -21,7 +23,7 @@ const AuthContext = createContext({});
 export const useAuthContext = () => useContext(AuthContext) as AuthContextType;
 
 function AuthProvider({ children }: Props) {
-  const [user, setUser] = useLocalStorage('user', {});
+  const [user, setUser] = useLocalStorage<Partial<UserAPI>>('user', {});
   const [token, setToken] = useLocalStorage('token', '');
 
   const login = useCallback(

--- a/src/pages/QuizResultPage/index.tsx
+++ b/src/pages/QuizResultPage/index.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
-import { useSessionStorage } from '@hooks/useStorage';
+import React, { useEffect, useMemo, useState } from 'react';
 import QuizResult from '@components/QuizResult';
-import { USER_ANSWERS, POST_IDS } from '@/common/string';
-import QuizMockData from '@/assets/QuizMockData';
+import { Quiz as QuizInterface } from '@/interfaces/Quiz';
+import * as QuizServices from '@/utils/QuizServices';
 import * as S from './styles';
 
 /**
@@ -13,17 +12,37 @@ import * as S from './styles';
  * 4. random인지, random인지 아닌지 저장해야 한다.
  */
 function QuizResultPage() {
-  const [mockData] = useState(QuizMockData);
-  const [solvedPostIds] = useSessionStorage<string[]>(POST_IDS, []);
-  const [userAnswers] = useSessionStorage<string[]>(
-    USER_ANSWERS,
-    Array(solvedPostIds.length).fill(''),
+  const [quizzes, setQuizzes] = useState<QuizInterface[]>([]);
+  // TODO: 67 branch 머지 시 변경 필요
+  const solvedPostIds = useMemo(
+    () => [
+      '62ac3cc2377cfd03a86b54c0',
+      '62ac3c72377cfd03a86b54b8',
+      '62aaf228e193b3692eddfb96',
+      '62aaf058e193b3692eddfb08',
+    ],
+    [],
   );
+  const userAnswers = useMemo(() => ['true', 'false', 'true', 'false'], []);
   // TODO: implement validation logics
   // if userAnswers.length !== userAnswers.filter(answer => answer).length -> 404page
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      try {
+        // TODO: 67 branch 머지시 변경 필요
+        const q = await QuizServices.getQuizzes(solvedPostIds);
+        setQuizzes(q);
+      } catch (error) {
+        throw new Error('error occured at fetchPosts');
+      }
+    };
+    fetchPosts();
+  }, [solvedPostIds]);
+
   return (
     <S.QuizResultPage>
-      {mockData.map((mock, index) => (
+      {quizzes.map((mock, index) => (
         <React.Fragment key={mock._id}>
           <QuizResult
             quiz={mock}

--- a/src/utils/UserServices.ts
+++ b/src/utils/UserServices.ts
@@ -1,11 +1,35 @@
+import { AxiosRequestHeaders } from 'axios';
 import api from '@/api/apiInstance';
+import { CommentAPI } from '@/interfaces/CommentAPI';
+import { LikeAPI } from '@/interfaces/LikeAPI';
+
+const headers: AxiosRequestHeaders = {
+  Authorization: `Bearer ${JSON.parse(localStorage.getItem('token') || '')}`,
+};
 
 export function like(postId: string) {
-  return api.post('/likes/create', { postId });
+  return api
+    .post<LikeAPI>(
+      '/likes/create',
+      { postId },
+      {
+        headers: { ...headers },
+      },
+    )
+    .then((response) => response.data)
+    .catch(() => {
+      throw new Error('error occuread at like.');
+    });
 }
 
-export function cancelLike(postId: string) {
-  return api.post('/likes/delete', { postId });
+export function cancelLike(likeId: string) {
+  return api.post(
+    '/likes/delete',
+    { id: likeId },
+    {
+      headers: { ...headers },
+    },
+  );
 }
 
 export function createComment({
@@ -15,9 +39,21 @@ export function createComment({
   comment: string;
   postId: string;
 }) {
-  return api.post('/comments/create', { comment, postId });
+  return api
+    .post<CommentAPI>(
+      '/comments/create',
+      { comment, postId },
+      {
+        headers: { ...headers },
+      },
+    )
+    .then((response) => response.data)
+    .catch((error) => {
+      console.error(error);
+      throw new Error('error occured at createComment.');
+    });
 }
 
 export function deleteComment(commentId: string) {
-  return api.delete('/comments/delete', { data: { id: commentId } });
+  return api.delete('/comments/delete', { data: { id: commentId }, headers });
 }

--- a/src/utils/UserServices.ts
+++ b/src/utils/UserServices.ts
@@ -23,13 +23,7 @@ export function like(postId: string) {
 }
 
 export function cancelLike(likeId: string) {
-  return api.post(
-    '/likes/delete',
-    { id: likeId },
-    {
-      headers: { ...headers },
-    },
-  );
+  return api.delete('/likes/delete', { data: { id: likeId }, headers });
 }
 
 export function createComment({

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -1,0 +1,28 @@
+/**
+ * ANCHOR: 10보다 작으면 앞에 0을 붙여주는 함수
+ */
+export function format(number: number) {
+  return number < 10 ? `0${number}` : `${number}`;
+}
+
+export default function dateFormat(dateString: string) {
+  const specificDate = new Date(dateString);
+  const now = new Date();
+  const _ = format;
+
+  /**
+   * 작성 시간이 오늘을 넘기지 않았다면, 시간, 분을 표시한다.
+   * 작성 시간이 오늘 날짜가 아니라면, 월, 일을 표시한다.
+   * 작성 시간이 올해가 아니라면, 년, 월을 표시한다.
+   */
+  const year = specificDate.getFullYear();
+  const month = specificDate.getMonth();
+  const date = specificDate.getDate();
+  const hours = specificDate.getHours();
+  const minutes = specificDate.getMinutes();
+
+  if (year === now.getFullYear() && date === now.getDate())
+    return `${_(hours)}:${_(minutes)}`;
+  if (year === now.getFullYear()) return `${_(month + 1)}.${_(date)}`;
+  return `${_(year).slice(-2, _(year).length)}.${_(month + 1)}`;
+}


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 임의의 postsId를 받아와 코멘트와 좋아요를 누를 수 있는 api를 연결하였습니다.
- 임의의 post는 67번 브랜치가 머지되면 반영할 예정입니다.

**테스트 실시한 사용자 계정: postman에 있는 사용자 로그인 정보를 사용했습니다.**

### 테스트 방법

`localhost:3000/result` 페이지로 이동 후 테스트 (로그인, 로그아웃은 LoginForm을 불러온 다음에 시도할 수 있습니다.)

### 로직 설명

1. 퀴즈들이 로딩되면, 각 퀴즈 결과 컴포넌트에서 코멘트와 좋아요 배열을 저장합니다.
2. 로그인한 사용자는 댓글을 작성할 수 있습니다. 또 자기가 작성한 댓글은 삭제가 가능합니다.
3. 모든 유저들은 각 문제당 한번씩 좋아요를 누를 수 있으며, 이미 좋아요한 문제는 다시 좋아요를 클릭하면 좋아요가 취소됩니다.

- 현재 댓글을 작성후 submit하면 사용자가 작성한 댓글이 컴포넌트에 바로 노출되지만, 사용자가 댓글을 작성하는 도중 다른 사용자가 댓글을 먼저 작성한 건에 대해서는 페이지가 리렌더링 되지 않는 이상 반영되지 않습니다. 이는 좋아요 역시 마찬가지로, 해당 부분은 api와 관련 있기 때문에 아직 지원하지 않습니다.

### 예시

- 로그인하지 않았을 때
![resultpage_logout](https://user-images.githubusercontent.com/56826914/174472216-f34c2463-3746-41f4-bc5e-a8a8e5cb9102.gif)

- 로그인 했을 때
![resultpage_login](https://user-images.githubusercontent.com/56826914/174472591-57323241-40a5-49ec-93d7-55abda12153f.gif)


## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- f04fce0: AuthContext ReturnType에 user option이 빠져 있어 다른 파일에서 접근이 불가능함을 확인하여 이를 수정했습니다.
- 878ce55: 전반적인 UserServices api 개선이 있었으나, 아래 커밋에서 버그를 발견하여 추가로 수정하였습니다.
- dde4661: 댓글 작성 로직을 추가하였습니다.
- c9b63b0: 좋아요 로직을 추가하였습니다.
- 19cf961: 임시로 사용할 date format 함수를 추가하였습니다.
- 86a2810: 로직의 전반적인 리팩토링을 진행하여 가독성을 향상시켰습니다.

## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
1. 테스트해보고 안되면 꼭!! 리뷰 부탁드립니다.
2. 가독성 관련하여 개선할 점이 있으면 반영하겠습니다.

close #69 