### PR TITLE
[Feat] QuizSolvePage와 QuizResultPage 연동 및 총 점수 저장

### DIFF
--- a/src/api/UserServices.ts
+++ b/src/api/UserServices.ts
@@ -2,7 +2,7 @@ import { AxiosRequestHeaders } from 'axios';
 import api from '@/api/axiosInstance';
 import { CommentAPI } from '@/interfaces/CommentAPI';
 import { LikeAPI } from '@/interfaces/LikeAPI';
-import { UserQuizInfo } from '@/interfaces/UserAPI';
+import { UserAPI, UserQuizPostAPI } from '@/interfaces/UserAPI';
 
 const isNotNull = (item: string | null): item is string => {
   return !!item;
@@ -66,11 +66,11 @@ export function deleteComment(commentId: string) {
   });
 }
 
-export function updateTotalPoint(info: UserQuizInfo) {
+export function updateTotalPoint(info: UserQuizPostAPI) {
   return api
-    .put(
+    .put<UserAPI>(
       '/settings/update-user',
-      { username: JSON.stringify(info) },
+      { ...info, username: JSON.stringify(info.username) },
       { headers: { ...getHeaders() } },
     )
     .then((response) => response.data)

--- a/src/api/UserServices.ts
+++ b/src/api/UserServices.ts
@@ -2,6 +2,7 @@ import { AxiosRequestHeaders } from 'axios';
 import api from '@/api/axiosInstance';
 import { CommentAPI } from '@/interfaces/CommentAPI';
 import { LikeAPI } from '@/interfaces/LikeAPI';
+import { UserQuizInfo } from '@/interfaces/UserAPI';
 
 const isNotNull = (item: string | null): item is string => {
   return !!item;
@@ -63,4 +64,17 @@ export function deleteComment(commentId: string) {
     data: { id: commentId },
     headers: { ...getHeaders() },
   });
+}
+
+export function updateTotalPoint(info: UserQuizInfo) {
+  return api
+    .put(
+      '/settings/update-user',
+      { username: JSON.stringify(info) },
+      { headers: { ...getHeaders() } },
+    )
+    .then((response) => response.data)
+    .catch(() => {
+      throw new Error('error occured at updateTotalPoint.');
+    });
 }

--- a/src/common/string.ts
+++ b/src/common/string.ts
@@ -6,7 +6,3 @@ export const PINK = 'pink';
 export const BROWN = 'brown';
 export const NOLIKES = 'noLikes';
 export const NOCOMMENTS = 'noComments';
-
-// used in QuizSolve and QuizResults pages.
-export const POST_IDS = 'post-ids' as const;
-export const USER_ANSWERS = 'user-answers' as const;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -24,3 +24,8 @@ export const QUIZ_SET_TAG_LIST = [
   'Web',
   'CS지식',
 ];
+
+// used in QuizSolve and QuizResults pages.
+export const POST_IDS = 'post-ids';
+export const USER_ANSWERS = 'user-answers';
+export const POINTS = 'points';

--- a/src/contexts/AuthContext/index.tsx
+++ b/src/contexts/AuthContext/index.tsx
@@ -21,6 +21,7 @@ interface AuthContextType {
   login: (formData: LoginFormData) => Promise<void>;
   signUp: (formData: Partial<SignUpFormData>) => Promise<void>;
   authUser: () => Promise<void>;
+  setUser: (value: UserAPI) => void;
   isAuth: boolean;
 }
 
@@ -93,9 +94,10 @@ function AuthProvider({ children }: Props) {
           login,
           signUp,
           authUser,
+          setUser,
           isAuth,
         }),
-        [user, token, login, signUp, authUser, isAuth],
+        [user, token, login, signUp, authUser, setUser, isAuth],
       )}
     >
       {children}

--- a/src/interfaces/UserAPI.d.ts
+++ b/src/interfaces/UserAPI.d.ts
@@ -82,3 +82,8 @@ export interface UserQuizType {
   comments: CommentAPI[];
   likes: LikeAPI[];
 }
+
+export interface UserQuizInfo {
+  id: string;
+  points: number;
+}

--- a/src/interfaces/UserAPI.d.ts
+++ b/src/interfaces/UserAPI.d.ts
@@ -84,6 +84,11 @@ export interface UserQuizType {
 }
 
 export interface UserQuizInfo {
-  id: string;
+  _id: string;
   points: number;
+}
+
+export interface UserQuizPostAPI {
+  fullName: string;
+  username: UserQUizInfo;
 }

--- a/src/pages/QuizResultPage/index.tsx
+++ b/src/pages/QuizResultPage/index.tsx
@@ -34,13 +34,12 @@ function QuizResultPage() {
 
   return (
     <S.QuizResultPage>
-      {quizzes.map((mock, index) => (
-        <React.Fragment key={mock._id}>
-          <QuizResult
-            quiz={mock}
-            correct={mock.answer === userAnswers[index]}
-          />
-        </React.Fragment>
+      {quizzes.map((quiz, index) => (
+        <QuizResult
+          key={quiz._id}
+          quiz={quiz}
+          correct={quiz.answer === userAnswers[index]}
+        />
       ))}
       <div>
         {/** TODO: 링크 수정 필요 */}

--- a/src/pages/QuizResultPage/index.tsx
+++ b/src/pages/QuizResultPage/index.tsx
@@ -3,6 +3,8 @@ import QuizResult from '@components/QuizResult';
 import { Quiz as QuizInterface } from '@/interfaces/Quiz';
 import * as QuizServices from '@/api/QuizServices';
 import * as S from './styles';
+import { useSessionStorage } from '@/hooks/useStorage';
+import { POST_IDS } from '@/constants';
 
 /**
  * ANCHOR: QuizResultPage 로직
@@ -13,16 +15,7 @@ import * as S from './styles';
  */
 function QuizResultPage() {
   const [quizzes, setQuizzes] = useState<QuizInterface[]>([]);
-  // TODO: 67 branch 머지 시 변경 필요
-  const solvedPostIds = useMemo(
-    () => [
-      '62ac3cc2377cfd03a86b54c0',
-      '62ac3c72377cfd03a86b54b8',
-      '62aaf228e193b3692eddfb96',
-      '62aaf058e193b3692eddfb08',
-    ],
-    [],
-  );
+  const [postIds] = useSessionStorage<string[]>(POST_IDS, []);
   const userAnswers = useMemo(() => ['true', 'false', 'true', 'false'], []);
   // TODO: implement validation logics
   // if userAnswers.length !== userAnswers.filter(answer => answer).length -> 404page
@@ -30,15 +23,14 @@ function QuizResultPage() {
   useEffect(() => {
     const fetchPosts = async () => {
       try {
-        // TODO: 67 branch 머지시 변경 필요
-        const q = await QuizServices.getQuizzesFromPostIds(solvedPostIds);
-        setQuizzes(q);
+        const qs = await QuizServices.getQuizzesFromPostIds(postIds);
+        setQuizzes(qs);
       } catch (error) {
         throw new Error('error occured at fetchPosts');
       }
     };
     fetchPosts();
-  }, [solvedPostIds]);
+  }, [postIds]);
 
   return (
     <S.QuizResultPage>

--- a/src/pages/QuizSolvePage/index.tsx
+++ b/src/pages/QuizSolvePage/index.tsx
@@ -8,17 +8,21 @@ import React, {
 import Quiz from '@components/Quiz';
 import { useHistory } from 'react-router';
 import Slider from 'react-slick';
-import { POST_IDS, USER_ANSWERS } from '@/constants';
+import { POINTS, POST_IDS, USER_ANSWERS } from '@/constants';
 import * as QuizServices from '@/api/QuizServices';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import SliderButton from './SliderButton';
 import { Quiz as QuizInterface } from '@/interfaces/Quiz';
 import * as S from './styles';
+import { useAuthContext } from '@/contexts/AuthContext';
+import { UserQuizInfo } from '@/interfaces/UserAPI';
+import { updateTotalPoint } from '@/api/UserServices';
 
 function QuizSolvePage(): JSX.Element {
   const history = useHistory();
   const sliderRef = useRef<Slider | null>(null);
+  const { user, setUser, isAuth } = useAuthContext();
 
   // TODO: 추후 ContextAPI로 관리할 예정
   const quizLength = useRef(6);
@@ -34,8 +38,33 @@ function QuizSolvePage(): JSX.Element {
     );
   }, []);
 
+  const updateUserPoint = useCallback(async () => {
+    try {
+      const totalPoint = QuizServices.caculateScore(quizzes, userAnswers);
+      sessionStorage.setItem(POINTS, JSON.stringify(totalPoint));
+
+      const newInfo = {
+        _id: String(Math.random()),
+        points: totalPoint,
+      };
+      if (user.username) {
+        const prevUserInfo = JSON.parse(user.username) as UserQuizInfo;
+        if (prevUserInfo._id) newInfo._id = prevUserInfo._id;
+        if (prevUserInfo.points)
+          newInfo.points = totalPoint + prevUserInfo.points;
+      }
+      const newUserInfo = await updateTotalPoint({
+        fullName: user.fullName,
+        username: newInfo,
+      });
+      setUser(newUserInfo);
+    } catch (error) {
+      console.log('error occured at updateUserPoint.');
+    }
+  }, [quizzes, setUser, user.fullName, user.username, userAnswers]);
+
   const handleSubmit = useCallback(
-    (e: React.FormEvent) => {
+    async (e: React.FormEvent) => {
       e.preventDefault();
       // validation
       if (quizzes.length !== userAnswers.filter((answer) => answer).length) {
@@ -50,10 +79,13 @@ function QuizSolvePage(): JSX.Element {
       );
 
       // 로그인했다면, 사용자의 점수를 반영
+      if (isAuth) {
+        await updateUserPoint();
+      }
 
       history.push('/result');
     },
-    [history, quizzes, userAnswers],
+    [history, isAuth, quizzes, updateUserPoint, userAnswers],
   );
 
   // Slider Options
@@ -76,6 +108,7 @@ function QuizSolvePage(): JSX.Element {
     // initialize
     sessionStorage.removeItem(POST_IDS);
     sessionStorage.removeItem(USER_ANSWERS);
+    sessionStorage.removeItem(POINTS);
 
     const fetchRandomQuizzes = async () => {
       try {

--- a/src/pages/QuizSolvePage/index.tsx
+++ b/src/pages/QuizSolvePage/index.tsx
@@ -8,7 +8,7 @@ import React, {
 import Quiz from '@components/Quiz';
 import { useHistory } from 'react-router';
 import Slider from 'react-slick';
-import { POST_IDS, USER_ANSWERS } from '@/common/string';
+import { POST_IDS, USER_ANSWERS } from '@/constants';
 import * as QuizServices from '@/api/QuizServices';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
@@ -48,6 +48,9 @@ function QuizSolvePage(): JSX.Element {
         POST_IDS,
         JSON.stringify(quizzes.map((quiz) => quiz._id)),
       );
+
+      // 로그인했다면, 사용자의 점수를 반영
+
       history.push('/result');
     },
     [history, quizzes, userAnswers],

--- a/src/pages/QuizSolvePage/index.tsx
+++ b/src/pages/QuizSolvePage/index.tsx
@@ -8,6 +8,7 @@ import React, {
 import Quiz from '@components/Quiz';
 import { useHistory } from 'react-router';
 import Slider from 'react-slick';
+import { v4 } from 'uuid';
 import { POINTS, POST_IDS, USER_ANSWERS } from '@/constants';
 import * as QuizServices from '@/api/QuizServices';
 import 'slick-carousel/slick/slick.css';
@@ -44,7 +45,7 @@ function QuizSolvePage(): JSX.Element {
       sessionStorage.setItem(POINTS, JSON.stringify(totalPoint));
 
       const newInfo = {
-        _id: String(Math.random()),
+        _id: v4(),
         points: totalPoint,
       };
       if (user.username) {


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

- QuizSolvePage와 QuizResultPage의 정보를 연동했습니다.
- 로그인 한 유저에 대하여 문제를 해결하고 나면 점수가 반영되도록 하였습니다.

- 문제 풀고 난 뒤 점수를 임시 저장
<img width="261" alt="score" src="https://user-images.githubusercontent.com/56826914/174558540-86cdc44b-0780-431d-a132-3ff069766204.png">

- 총 점수를 유저 객체에 반영
<img width="443" alt="user" src="https://user-images.githubusercontent.com/56826914/174558545-55b533b5-49f8-406f-903d-88ec41707c90.png">

- QuizSolvePage랑 QuizResultPage 연동
![connection](https://user-images.githubusercontent.com/56826914/174558975-56dce03a-bb97-46e0-ade2-66734462475c.gif)




## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 92ecbba: 점수 반영을 위한 인터페이스 구성
- 5d84583: 바뀐 유저 정보를 저장하기 위하여 setUser함수를 리턴값으로 가지도록 하였습니다.
- aa0f471: 로그인한 사용자에 대하여 점수가 반영됩니다.

**updateUserPoint 함수가 사용자 점수를 업데이트 하는 함수인데, 혹시 모를 예외 케이스에 대비하여 validation을 추가하였습니다.**

## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 테스트시 이상이 있을 경우 리뷰 부탁드립니다!!

close #84 