### PR TITLE
[Feat] 유저 정보 화면에서 유저 카드, 유저 탭 연결

### DIFF
--- a/src/components/UserInfo/UserInfoCard/index.tsx
+++ b/src/components/UserInfo/UserInfoCard/index.tsx
@@ -4,10 +4,10 @@ import * as S from './styles';
 import * as Breakpoints from '../breakpoints';
 import { BadgeType } from '@/interfaces/BadgeType';
 import {
-  customUserAPI,
+  CustomUserAPI,
   UserAPI,
-  userQuizCategory,
-  userSimpleType,
+  UserQuizCategory,
+  UserSimpleType,
 } from '@/interfaces/UserAPI';
 import { fetchUserData, fetchUserList, fetchUserQuiz } from '@/api/user';
 import { DEFAULT_USER_DATA } from '@/assets/UserInfoDefault';
@@ -15,9 +15,9 @@ import { PostAPIUserInfo } from '@/interfaces/PostAPI';
 import { getUserImageByPoints } from '@/utils/getUserImage';
 
 function UserInfoCard({ id, width = '40rem' }: { id: string; width?: string }) {
-  const [userData, setUserData] = useState<customUserAPI>(DEFAULT_USER_DATA);
+  const [userData, setUserData] = useState<CustomUserAPI>(DEFAULT_USER_DATA);
   const [userRank, setUserRank] = useState(0);
-  const [userQuiz, setUserQuiz] = useState<userQuizCategory[]>([]);
+  const [userQuiz, setUserQuiz] = useState<UserQuizCategory[]>([]);
 
   useEffect(() => {
     const updateUserData = async () => {
@@ -43,7 +43,7 @@ function UserInfoCard({ id, width = '40rem' }: { id: string; width?: string }) {
           points: user.username ? JSON.parse(user.username).points : 0,
           createdAt: user.createdAt,
         }))
-        .sort((userA: userSimpleType, userB: userSimpleType) => {
+        .sort((userA: UserSimpleType, userB: UserSimpleType) => {
           if (userB.points === userA.points) {
             const isCreatedFirst =
               new Date(userB.createdAt ? userB.createdAt : '') <
@@ -53,7 +53,7 @@ function UserInfoCard({ id, width = '40rem' }: { id: string; width?: string }) {
           return userB.points - userA.points;
         });
       const rank =
-        realData.findIndex((user: userSimpleType) => user.id === id) + 1;
+        realData.findIndex((user: UserSimpleType) => user.id === id) + 1;
       setUserRank(rank);
     };
 

--- a/src/components/UserInfo/UserInfoCard/styles.tsx
+++ b/src/components/UserInfo/UserInfoCard/styles.tsx
@@ -18,6 +18,7 @@ export const UserCard = styled(Card)<CardProps>`
   width: ${(props) => props.width};
   height: 14rem;
   padding: 1rem;
+  margin-top: 1rem;
 `;
 
 export const Username = styled.h2`

--- a/src/components/UserInfo/UserInfoTab/index.tsx
+++ b/src/components/UserInfo/UserInfoTab/index.tsx
@@ -77,10 +77,6 @@ function UserInfoTab({ id }: { id: string }) {
             />
           ))}
         </S.TabItemContainer>
-        <S.ButtonWrapper>
-          <S.Button color="#5B9785">퀴즈 수정</S.Button>
-          <S.Button color="#CE4C4C">퀴즈 삭제</S.Button>
-        </S.ButtonWrapper>
       </S.TabMenus>
 
       <S.TabContent>

--- a/src/components/UserInfo/UserInfoTab/styles.tsx
+++ b/src/components/UserInfo/UserInfoTab/styles.tsx
@@ -59,32 +59,6 @@ export const TabItem = styled.div<tabItemProps>`
   }
 `;
 
-export const ButtonWrapper = styled.div`
-  display: inline-flex;
-  gap: 0.5rem;
-`;
-
-type buttonProps = {
-  color?: string;
-  selected?: boolean;
-};
-export const Button = styled.button<buttonProps>`
-  border: 3px solid #343a40;
-  border-radius: 8px;
-  width: 9rem;
-  height: 2.5rem;
-  font-size: 1rem;
-  font-family: 'MaplestoryOTFLight', sans-serif;
-  background-color: ${({ color }) => color};
-  color: white;
-  cursor: pointer;
-  filter: ${({ selected }) => (selected ? `brightness(120%)` : null)};
-
-  &:hover {
-    filter: brightness(120%);
-  }
-`;
-
 export const UserQuizContainer = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/src/components/UserInfo/UserInfoTab/styles.tsx
+++ b/src/components/UserInfo/UserInfoTab/styles.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { lightGrayWhite, primary } from '@/styles/theme';
 
 export const TabWrapper = styled.div`
-  margin-top: 4rem;
+  margin-top: 2rem;
   width: 100%;
   min-width: 20rem;
 `;

--- a/src/interfaces/UserAPI.d.ts
+++ b/src/interfaces/UserAPI.d.ts
@@ -1,11 +1,6 @@
 import { CommentAPI } from './CommentAPI.d';
 import { PostAPI } from './PostAPI';
 
-export interface UserInfo {
-  _id: string;
-  points: number;
-}
-
 export interface NotificationAPI {
   seen: boolean;
   _id: string;
@@ -50,7 +45,7 @@ export interface UserAPI {
   username?: string;
 }
 
-export interface customUserAPI {
+export interface CustomUserAPI {
   id: string;
   fullName: string;
   posts: PostAPI[];
@@ -58,13 +53,13 @@ export interface customUserAPI {
   comments: CommentAPI[] | string[];
   totalExp?: number;
 }
-export interface userSimpleType {
+export interface UserSimpleType {
   id: string;
   fullName: string;
   points: number;
   createdAt?: string;
 }
-export interface userQuizCategory {
+export interface UserQuizCategory {
   id: string;
   category: string;
 }

--- a/src/pages/UserInfo.tsx
+++ b/src/pages/UserInfo.tsx
@@ -3,17 +3,30 @@ import { useParams } from 'react-router';
 import Header from '@/components/Header';
 import UserInfoCard from '@/components/UserInfo/UserInfoCard';
 import UserInfoTab from '@/components/UserInfo/UserInfoTab';
+import { fetchUserList } from '@/api/user';
+import { UserAPI } from '@/interfaces/UserAPI';
 
 interface Props {
   userId: string;
 }
 function UserInfo() {
+  const [valid, setValid] = useState(false);
   const [id, setId] = useState('');
 
   const params = useParams<Props>();
   useEffect(() => {
+    const setValidId = async (urlId: string) => {
+      const apiData = await fetchUserList();
+      const idList = apiData.map((user: UserAPI) => user._id);
+      const isValid = idList.some((item: string) => item === urlId);
+      setValid(isValid);
+      if (isValid) {
+        setId(urlId);
+      }
+    };
+
     const { userId } = params;
-    setId(userId);
+    setValidId(userId);
   }, [params]);
 
   return (

--- a/src/pages/UserInfo.tsx
+++ b/src/pages/UserInfo.tsx
@@ -1,13 +1,26 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router';
 import Header from '@/components/Header';
 import UserInfoCard from '@/components/UserInfo/UserInfoCard';
 import UserInfoTab from '@/components/UserInfo/UserInfoTab';
 
+interface Props {
+  userId: string;
+}
 function UserInfo() {
+  const [id, setId] = useState('');
+
+  const params = useParams<Props>();
+  useEffect(() => {
+    const { userId } = params;
+    setId(userId);
+  }, [params]);
+
   return (
     <div>
       <Header />
-      <UserInfoCard id="62aafe7ce193b3692eddfc77" />
-      <UserInfoTab id="62aafe7ce193b3692eddfc77" />
+      {id && <UserInfoCard id={id} />}
+      {id && <UserInfoTab id={id} />}
     </div>
   );
 }

--- a/src/pages/UserInfoPage/index.tsx
+++ b/src/pages/UserInfoPage/index.tsx
@@ -13,10 +13,12 @@ interface Props {
 function UserInfo() {
   const [valid, setValid] = useState(false);
   const [id, setId] = useState('');
+  const [loading, isLoading] = useState(false);
 
   const params = useParams<Props>();
   useEffect(() => {
     const setValidId = async (urlId: string) => {
+      isLoading(true);
       const apiData = await fetchUserList();
       const idList = apiData.map((user: UserAPI) => user._id);
       const isValid = idList.some((item: string) => item === urlId);
@@ -24,6 +26,7 @@ function UserInfo() {
       if (isValid) {
         setId(urlId);
       }
+      isLoading(false);
     };
 
     const { userId } = params;
@@ -33,11 +36,15 @@ function UserInfo() {
   return (
     <div>
       <Header />
-      {!valid && (
-        <S.notFoundText>해당 유저는 존재하지 않습니다.</S.notFoundText>
+      {!loading && (
+        <>
+          {!valid && (
+            <S.notFoundText>해당 유저는 존재하지 않습니다.</S.notFoundText>
+          )}
+          {id && <UserInfoCard id={id} />}
+          {id && <UserInfoTab id={id} />}
+        </>
       )}
-      {id && <UserInfoCard id={id} />}
-      {id && <UserInfoTab id={id} />}
     </div>
   );
 }

--- a/src/pages/UserInfoPage/index.tsx
+++ b/src/pages/UserInfoPage/index.tsx
@@ -32,6 +32,7 @@ function UserInfo() {
   return (
     <div>
       <Header />
+      {!valid && <h3>해당 유저는 존재하지 않습니다.</h3>}
       {id && <UserInfoCard id={id} />}
       {id && <UserInfoTab id={id} />}
     </div>

--- a/src/pages/UserInfoPage/index.tsx
+++ b/src/pages/UserInfoPage/index.tsx
@@ -5,6 +5,7 @@ import UserInfoCard from '@/components/UserInfo/UserInfoCard';
 import UserInfoTab from '@/components/UserInfo/UserInfoTab';
 import { fetchUserList } from '@/api/user';
 import { UserAPI } from '@/interfaces/UserAPI';
+import * as S from './styles';
 
 interface Props {
   userId: string;
@@ -32,7 +33,9 @@ function UserInfo() {
   return (
     <div>
       <Header />
-      {!valid && <h3>해당 유저는 존재하지 않습니다.</h3>}
+      {!valid && (
+        <S.notFoundText>해당 유저는 존재하지 않습니다.</S.notFoundText>
+      )}
       {id && <UserInfoCard id={id} />}
       {id && <UserInfoTab id={id} />}
     </div>

--- a/src/pages/UserInfoPage/styles.tsx
+++ b/src/pages/UserInfoPage/styles.tsx
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+import { h2 } from '@/styles/theme';
+
+export const notFoundText = styled.h2`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0 auto;
+  width: 80%;
+  height: 35rem;
+  ${h2}
+`;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -5,7 +5,7 @@ import Home from '@/pages/Home';
 import QuizCreate from '@/pages/QuizCreate';
 import QuizSolvePage from '@/pages/QuizSolvePage';
 import QuizResultPage from '@/pages/QuizResultPage';
-import UserInfo from '@/pages/UserInfo';
+import UserInfoPage from '@/pages/UserInfoPage';
 import Ranking from '@/pages/Ranking';
 import Error from '@/pages/Error';
 
@@ -19,7 +19,7 @@ function Routers() {
         <AuthRoute exact path="/solve" component={QuizSolvePage} />
         <AuthRoute exact path="/result" component={QuizResultPage} />
         <AuthRoute exact path="/ranking" component={Ranking} />
-        <AuthRoute path="/user/:userId" component={UserInfo} />
+        <AuthRoute path="/user/:userId" component={UserInfoPage} />
         <AuthRoute path="/error" component={Error} />
         <AuthRoute path="/" component={Home} />
         <AuthRoute path="*" render={() => <Redirect to="/" />} />

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -18,8 +18,8 @@ function Routers() {
         <AuthRoute exact path="/create" component={QuizCreate} mode="private" />
         <AuthRoute exact path="/solve" component={QuizSolvePage} />
         <AuthRoute exact path="/result" component={QuizResultPage} />
-        <AuthRoute path="/user" component={UserInfo} />
         <AuthRoute exact path="/ranking" component={Ranking} />
+        <AuthRoute path="/user/:userId" component={UserInfo} />
         <AuthRoute path="/error" component={Error} />
         <AuthRoute path="/" component={Home} />
         <AuthRoute path="*" render={() => <Redirect to="/" />} />


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 유저 정보 화면으로 이동 시, 해당 id에 맞는 유저카드, 탭이 표시됩니다.
- 유효하지 않은 id로 접근할 시 `해당 유저는 존재하지 않습니다.` 가 표시됩니다.
### 테스트 방법
http://localhost:3000/user/62aaeb11e193b3692eddfa11 
이런 식으로 `/user/userId` 로 접근하면 해당 페이지가 뜹니다!
( 현재 예시 id는 프롱이 아이디 입니다) 

![image](https://user-images.githubusercontent.com/39826053/174562290-fcce6b4d-8e2f-48b4-8c4e-5b9e4b2bcc2b.png)

## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

> 32752b2acb8df231158321ef56b3eb66fe473fe6 사용하지 않는 UserInfo 인터페이스 삭제, 제가 구현한 모든 인터페이스를 대문자로 시작하도록 통일했습니다.  
> 5c19339df5fd063515708e848707c7967d9acda8 url에 따른 페이지로 이동합니다.  
> 3316219896d58fb526ba4b2a621aadecbd216c49 해당 id가 userList에 있는지 validate 합니다.  
> 1a1828bf600d773911d8b060ffbd669ac47bad5d 다른 페이지와 통일성을 위해 위치를 옮기고, suffix로 -Page를 붙였습니다.  
> c3ee9d48400ff96dec6a05e9df5e2fd1083b8635 invalid 한 링크 조회 시 예외처리 UI를 구현했습니다.  
### 리뷰 반영 사항

> [f194eea](https://github.com/prgrms-fe-devcourse/FEDC2_CheQuiz_Gidong/pull/92/commits/f194eea02a4242d6a223b0eb4e5b41bf0a816d5b) 로딩 처리를 추가해 두었습니다.

## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
가독성, 로직 관련 개선점이 있다면 말씀해주세요!
close #80 