### PR TITLE
[Feat] QuizResultPage에 UserInfo 추가

### DIFF
--- a/src/components/UserInfo/UserInfoCard/styles.tsx
+++ b/src/components/UserInfo/UserInfoCard/styles.tsx
@@ -14,8 +14,6 @@ export const Card = styled.div`
 `;
 
 export const UserCard = styled(Card)<CardProps>`
-  position: relative;
-  top: 2rem;
   display: flex;
   width: ${(props) => props.width};
   height: 14rem;

--- a/src/pages/QuizResultPage/index.tsx
+++ b/src/pages/QuizResultPage/index.tsx
@@ -38,7 +38,7 @@ function QuizResultPage() {
 
   return (
     <>
-      <Header />
+      <Header isLogin={isAuth} />
       {isAuth ? <UserInfoCard id={user._id} width="100%" /> : null}
       <S.QuizResultPage>
         {quizzes.map((quiz, index) => (
@@ -49,7 +49,6 @@ function QuizResultPage() {
           />
         ))}
         <div>
-          {/** TODO: 링크 수정 필요 */}
           <S.LinkButton to="/" color="point" fill="true">
             다른 문제 풀러가기
           </S.LinkButton>

--- a/src/pages/QuizResultPage/index.tsx
+++ b/src/pages/QuizResultPage/index.tsx
@@ -5,6 +5,8 @@ import * as QuizServices from '@/api/QuizServices';
 import * as S from './styles';
 import { useSessionStorage } from '@/hooks/useStorage';
 import { POST_IDS } from '@/constants';
+import UserInfoCard from '@/components/UserInfo/UserInfoCard';
+import { useAuthContext } from '@/contexts/AuthContext';
 
 /**
  * ANCHOR: QuizResultPage 로직
@@ -14,6 +16,7 @@ import { POST_IDS } from '@/constants';
  * 4. random인지, random인지 아닌지 저장해야 한다.
  */
 function QuizResultPage() {
+  const { user, isAuth } = useAuthContext();
   const [quizzes, setQuizzes] = useState<QuizInterface[]>([]);
   const [postIds] = useSessionStorage<string[]>(POST_IDS, []);
   const userAnswers = useMemo(() => ['true', 'false', 'true', 'false'], []);
@@ -33,27 +36,30 @@ function QuizResultPage() {
   }, [postIds]);
 
   return (
-    <S.QuizResultPage>
-      {quizzes.map((quiz, index) => (
-        <QuizResult
-          key={quiz._id}
-          quiz={quiz}
-          correct={quiz.answer === userAnswers[index]}
-        />
-      ))}
-      <div>
-        {/** TODO: 링크 수정 필요 */}
-        <S.LinkButton to="/" color="point" fill="true">
-          다른 문제 풀러가기
-        </S.LinkButton>
-        <S.LinkButton to="/" color="point" fill="true">
-          랭킹 보기
-        </S.LinkButton>
-        <S.LinkButton to="/" color="point" fill="true">
-          퀴즈 만들러 가기
-        </S.LinkButton>
-      </div>
-    </S.QuizResultPage>
+    <>
+      {/* {isAuth ? <UserInfoCard id={user._id} width="100%" /> : null} */}
+      <S.QuizResultPage>
+        {quizzes.map((quiz, index) => (
+          <QuizResult
+            key={quiz._id}
+            quiz={quiz}
+            correct={quiz.answer === userAnswers[index]}
+          />
+        ))}
+        <div>
+          {/** TODO: 링크 수정 필요 */}
+          <S.LinkButton to="/" color="point" fill="true">
+            다른 문제 풀러가기
+          </S.LinkButton>
+          <S.LinkButton to="/ranking" color="point" fill="true">
+            랭킹 보기
+          </S.LinkButton>
+          <S.LinkButton to="/create" color="point" fill="true">
+            퀴즈 만들러 가기
+          </S.LinkButton>
+        </div>
+      </S.QuizResultPage>
+    </>
   );
 }
 

--- a/src/pages/QuizResultPage/index.tsx
+++ b/src/pages/QuizResultPage/index.tsx
@@ -7,6 +7,7 @@ import { useSessionStorage } from '@/hooks/useStorage';
 import { POST_IDS } from '@/constants';
 import UserInfoCard from '@/components/UserInfo/UserInfoCard';
 import { useAuthContext } from '@/contexts/AuthContext';
+import Header from '@/components/Header';
 
 /**
  * ANCHOR: QuizResultPage 로직
@@ -37,7 +38,8 @@ function QuizResultPage() {
 
   return (
     <>
-      {/* {isAuth ? <UserInfoCard id={user._id} width="100%" /> : null} */}
+      <Header />
+      {isAuth ? <UserInfoCard id={user._id} width="100%" /> : null}
       <S.QuizResultPage>
         {quizzes.map((quiz, index) => (
           <QuizResult


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- QuizResultPage에 헤더를 추가했습니다.
- QuizResultPAge에 UserInfoCard를 추가했습니다. 현재는 로그인되지 않은 경우에만 해당 컴포는트가 나타나며, 로그인을 유도하는 컴포넌트는 추후 처리하도록 하겠습니다.
- 하단 Link들에 페이지를 연결했습니다. 각각 `/`, `/ranking`, `/create` 페이지로 이동합니다.

일단 UserInfoCard의 position option 때문에 퀴즈 컴포넌트와 겹치는 문제가 있어서, 해당 문제를 수정하고자 position과 top옵션을 지웠습니다. 

## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 기능 동작 정도만 확인 주시면 감사하겠습니다.
- **solve페이지로 바로 접근할 경우 문제가 없기 때문에 아무 문제도 보이지 않으므로, /solve 페이에서 문제를 해결한 뒤 테스트가 가능합니다.**


close #93
