### PR TITLE
[Feat] MainPage와 SolvePage Context연결 및 진입 로직 구현

### DIFF
--- a/src/api/QuizServices.ts
+++ b/src/api/QuizServices.ts
@@ -56,6 +56,15 @@ function parseQuiz(post: PostAPI) {
   return { ...postCopy, ...JSON.parse(quizContent) } as Quiz;
 }
 
+function getPostsFromChannel(channelId: string): Promise<PostAPI[]> {
+  return api
+    .get<PostAPI[]>(`/posts/channel/${channelId}`)
+    .then((response) => response.data);
+}
+
+/**
+ * @deprecated
+ */
 export function getPostIdsFromChannel(channelName: string): Promise<string[]> {
   return api
     .get<ChannelAPI>(`/channels/${channelName}`)
@@ -66,6 +75,9 @@ export function getPostIdsFromChannel(channelName: string): Promise<string[]> {
     });
 }
 
+/**
+ * @deprecated
+ */
 export function getShuffledPostIds(count: number) {
   return getPostIds()
     .then((postIds) => shuffle(postIds, count))
@@ -74,7 +86,6 @@ export function getShuffledPostIds(count: number) {
     });
 }
 
-// ANCHOR: API 변경사항이 있다면, 가장 먼저 확인해야 할 부분
 export function getQuizzesFromPostIds(postIds: string[]): Promise<Quiz[]> {
   return getPostsFromPostIds(postIds)
     .then((response) => response.map((post) => parseQuiz(post)))
@@ -84,8 +95,8 @@ export function getQuizzesFromPostIds(postIds: string[]): Promise<Quiz[]> {
 }
 
 export function getQuizzesFromChannel(channelId: string) {
-  return getPostIdsFromChannel(channelId).then((postIds) =>
-    getQuizzesFromPostIds(postIds),
+  return getPostsFromChannel(channelId).then((posts) =>
+    posts.map((post) => parseQuiz(post)),
   );
 }
 

--- a/src/api/QuizServices.ts
+++ b/src/api/QuizServices.ts
@@ -83,8 +83,8 @@ export function getQuizzesFromPostIds(postIds: string[]): Promise<Quiz[]> {
     });
 }
 
-export function getQuizzesFromChannel(channelName: string) {
-  return getPostIdsFromChannel(channelName).then((postIds) =>
+export function getQuizzesFromChannel(channelId: string) {
+  return getPostIdsFromChannel(channelId).then((postIds) =>
     getQuizzesFromPostIds(postIds),
   );
 }

--- a/src/pages/QuizSolvePage/index.tsx
+++ b/src/pages/QuizSolvePage/index.tsx
@@ -143,7 +143,7 @@ function QuizSolvePage(): JSX.Element {
 
   return (
     <form onSubmit={handleSubmit}>
-      <div>
+      <S.QuizSolvePage>
         <S.Wrapper justify="center">
           <S.Box>
             {currentIndex + 1} / {quizzes.length}
@@ -190,7 +190,7 @@ function QuizSolvePage(): JSX.Element {
             제출
           </S.SelectButton>
         </S.Wrapper>
-      </div>
+      </S.QuizSolvePage>
     </form>
   );
 }

--- a/src/pages/QuizSolvePage/index.tsx
+++ b/src/pages/QuizSolvePage/index.tsx
@@ -123,10 +123,9 @@ function QuizSolvePage(): JSX.Element {
     };
 
     const fetchQuizzesFromChannel = async () => {
-      // TODO: sessionStorage에 channelId 저장 필요
       try {
         const quizzesFromChannel = await QuizServices.getQuizzesFromChannel(
-          'CheQuiz',
+          '62aaeb93e193b3692eddfa1c',
         );
         return quizzesFromChannel;
       } catch (error) {

--- a/src/pages/QuizSolvePage/styles.tsx
+++ b/src/pages/QuizSolvePage/styles.tsx
@@ -80,3 +80,7 @@ export const Box = styled.div`
   font-size: 1.25rem;
   font-family: 'MaplestoryOTFLight';
 `;
+
+export const QuizSolvePage = styled.div`
+  margin-top: 5rem;
+`;


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 메인페이지에서 퀴즈 푸는 페이지로 진입 시 진입 로직을 구현하였습니다.
- 메인페이지에서 랜덤 퀴즈를 풀 때 문제 개수를 선택하거나, 퀴즈 세트를 선택해야지만 문제를 풀 수 있기 때문에 다이렉트로 `/solve` 페이지로 들어오거나, 다른 페이지에서 `/solve` 페이지에 접근할 수 없도록 조치했습니다.
- 단, 아직 뒤로 가기 시에는 진입할 수 있기 때문에, 해당 부분을 만족하기 위해서 history api의 state를 사용해야 할 것으로 보입니다.

### 진입 로직

1. 사용자가 랜덤 퀴즈를 선택했다면, 랜덤 퀴즈를 요청하여 보여준다.
2. 사용자가 세트 퀴즈를 선택했다면, 채널 아이디를 이용하여 퀴즈를 요청하여 보내준다.
3. 두 값이 모두 비어있다면, error 페이지로 리다이렉트한다.

- 랜덤 퀴즈 풀기(현재 6문제밖에 없어서 10개 선택해도 6개가 나옵니다)
![random_quiz](https://user-images.githubusercontent.com/56826914/174701063-386b2dae-6b59-4137-8232-83de73d05887.gif)
- 세트 퀴즈 풀기(왜 0개 문제인 세트가 있는 걸까요??)
![set_quiz](https://user-images.githubusercontent.com/56826914/174701384-31b3a0f9-7193-49d3-9650-cae23e8f98bf.gif)


## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 047f8c5: 요청 주소가 다른 것을 확인했기 때문에 해당 부분 api를 수정했습니다. 그러므로 기존 api중 사용하지 않는 api를 deprecated 처리하였습니다.
- 35b7e51: 진입 로직을 구현하였습니다.

## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 테스트해보고 버그 발견시 리뷰 주시면 빠르게 고치겠습니다.

close #100 