### PR TITLE
[Feat] 메인페이지 필터 및 정렬 기능 추가

### DIFF
--- a/src/api/QuizServices.ts
+++ b/src/api/QuizServices.ts
@@ -115,3 +115,12 @@ export function caculateScore(quizzes: Quiz[], userAnswers: string[]) {
     .filter((quiz, index) => quiz.answer === userAnswers[index])
     .reduce((acc, cur) => acc + cur.difficulty * 10, 0);
 }
+
+export async function getChannels() {
+  return api
+    .get<ChannelAPI[]>('/channels')
+    .then((response) => response.data)
+    .catch(() => {
+      throw new Error('error occured at getChannels.');
+    });
+}

--- a/src/assets/QuizCreateMockData.ts
+++ b/src/assets/QuizCreateMockData.ts
@@ -3,7 +3,7 @@ import { QuizClientContent } from '@/interfaces/Quiz';
 const TEST_ADMIN_TOKEN = '';
 const TEST_USER_TOKEN =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7Il9pZCI6IjYyYWFlYjExZTE5M2IzNjkyZWRkZmExMSIsImVtYWlsIjoiYXNkZkBhc2RmLmNvbSJ9LCJpYXQiOjE2NTUzNjk2Nzh9.rnab-tJWPRmjF9rprydWuQcAWves_Xyhl6WJYyP2l4I';
-const DEFAULT_CHANNEL_ID = '62aaecbee193b3692eddfa60';
+const DEFAULT_CHANNEL_ID = '62b12aedaf3e834e8fb294c8';
 
 const QUIZ_ITEM_DEFAULT_STATE: QuizClientContent = {
   _id: 0,

--- a/src/components/Home/QuizSetList/index.tsx
+++ b/src/components/Home/QuizSetList/index.tsx
@@ -1,55 +1,102 @@
 import { useEffect, useState } from 'react';
-import api from '@/api/axiosInstance';
 import * as S from './styles';
 import Icon from '@/components/Icon';
 import QuizSetCard from '../QuizSetCard';
 import { ChannelAPI } from '@/interfaces/ChannelAPI';
 import { useQuizContext } from '@/contexts/QuizContext';
 import Select from '@/components/Form/Select';
+import { getChannels } from '@/api/QuizServices';
 
 function QuizSetList() {
   const [quizSetList, setQuizSetList] = useState<ChannelAPI[]>([]);
+  const [keyword, setKeyword] = useState<string>('');
+  const [sortBy, setSortBy] = useState<string>('new');
+
   const { setRandomQuizCategory, setRandomQuizCount, setChannelId } =
     useQuizContext();
 
   useEffect(() => {
-    const getQuizSetList = async () => {
-      const apiData = await api
-        .get<ChannelAPI[]>('/channels')
-        .then((response) => response.data);
+    const fetchQuizSets = async () => {
+      const apiData = await getChannels();
       setQuizSetList(apiData);
     };
-    getQuizSetList();
+
+    fetchQuizSets();
   }, []);
+
+  const handleInputChange = ({ target }: { target: HTMLInputElement }) => {
+    setKeyword(target.value);
+  };
+
+  const isContainKeyword = (quizSet: ChannelAPI) => {
+    const { name, description } = quizSet;
+    const { tags, creator } = JSON.parse(description);
+    const isFiltered =
+      name.indexOf(keyword) >= 0 ||
+      tags.includes(keyword) ||
+      creator.fullName.indexOf(keyword) >= 0;
+    return isFiltered;
+  };
+
   const handleQuizClick = (id: string) => {
     setRandomQuizCategory(null);
     setRandomQuizCount(null);
     setChannelId(id);
+  };
+
+  const sortBySelect = (
+    prev: ChannelAPI,
+    next: ChannelAPI,
+    sortValue: string,
+  ) => {
+    const byNewer = +new Date(next.createdAt) - +new Date(prev?.createdAt);
+    const byOlder = +new Date(prev.createdAt) - +new Date(next?.createdAt);
+
+    switch (sortValue) {
+      case 'new':
+        return byNewer;
+      case 'old':
+        return byOlder;
+      default:
+        return byNewer;
+    }
   };
   return (
     <section>
       <S.FilterContainer>
         <S.SearchWrap>
           <Icon name="search" strokeWidth={4} />
-          <S.SearchInput type="text" placeholder="검색" />
+          <S.SearchInput
+            type="text"
+            placeholder="검색"
+            value={keyword}
+            onChange={handleInputChange}
+          />
         </S.SearchWrap>
         <Select
           defaultValue="정렬"
-          options={['최신순', '좋아요순']}
+          options={[
+            { label: '최신순', value: 'new' },
+            { label: '오래된순', value: 'old' },
+          ]}
+          onChangeValue={(value: string) => setSortBy(value)}
           addStyle={{ width: '11rem', backgroundColor: '#DEE2E6' }}
         />
       </S.FilterContainer>
       <S.Title>지식 사냥터 </S.Title>
       <S.QuizSetListContainer>
-        {quizSetList.map((quizSet: ChannelAPI) => (
-          <S.LinkToSolve
-            to="/solve"
-            key={quizSet._id}
-            onClick={() => handleQuizClick(quizSet._id)}
-          >
-            <QuizSetCard quizSet={quizSet} />
-          </S.LinkToSolve>
-        ))}
+        {quizSetList
+          .filter(isContainKeyword)
+          .sort((a, b) => sortBySelect(a, b, sortBy))
+          .map((quizSet: ChannelAPI) => (
+            <S.LinkToSolve
+              to="/solve"
+              key={quizSet._id}
+              onClick={() => handleQuizClick(quizSet._id)}
+            >
+              <QuizSetCard quizSet={quizSet} />
+            </S.LinkToSolve>
+          ))}
       </S.QuizSetListContainer>
     </section>
   );

--- a/src/components/Home/QuizSetList/index.tsx
+++ b/src/components/Home/QuizSetList/index.tsx
@@ -34,10 +34,20 @@ function QuizSetList() {
   const isContainKeyword = (quizSet: ChannelAPI) => {
     const { name, description } = quizSet;
     const { tags, creator } = JSON.parse(description);
+
+    const parseValue = (value: string) => {
+      return value.replace(/\s/g, '').toLowerCase();
+    };
+
+    const lowerTitle = parseValue(name);
+    const lowerTags = tags.map((tag: string) => parseValue(tag));
+    const lowerUserName = parseValue(creator.fullName);
+    const lowerKeyword = parseValue(keyword);
+
     const isFiltered =
-      name.indexOf(keyword) >= 0 ||
-      tags.includes(keyword) ||
-      creator.fullName.indexOf(keyword) >= 0;
+      lowerTitle.indexOf(lowerKeyword) >= 0 ||
+      lowerTags.includes(lowerKeyword) ||
+      lowerUserName.indexOf(lowerKeyword) >= 0;
     return isFiltered;
   };
 

--- a/src/components/Home/QuizSetList/index.tsx
+++ b/src/components/Home/QuizSetList/index.tsx
@@ -6,6 +6,7 @@ import { ChannelAPI } from '@/interfaces/ChannelAPI';
 import { useQuizContext } from '@/contexts/QuizContext';
 import Select from '@/components/Form/Select';
 import { getChannels } from '@/api/QuizServices';
+import { DEFAULT_CHANNEL_ID } from '@/assets/QuizCreateMockData';
 
 function QuizSetList() {
   const [quizSetList, setQuizSetList] = useState<ChannelAPI[]>([]);
@@ -18,7 +19,9 @@ function QuizSetList() {
   useEffect(() => {
     const fetchQuizSets = async () => {
       const apiData = await getChannels();
-      setQuizSetList(apiData);
+      setQuizSetList(
+        apiData.filter((quizset) => quizset._id !== DEFAULT_CHANNEL_ID),
+      );
     };
 
     fetchQuizSets();


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
메인페이지 검색, 정렬에 의한 필터링 구현
- 현재 `set의 이름`, `tags`, `유저이름` 중에 하나라도 검색어가 포함되면 보여줍니다.
- 정렬은 좋아요가 없어져서, `최신순`, `오래된 순` 으로 필터합니다.

![0621_메인_서치_정렬_gif](https://user-images.githubusercontent.com/52021566/174706764-b1806d30-4a63-4d07-9e5b-584548f3bc9c.gif)


## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
[3984e8b](https://github.com/prgrms-fe-devcourse/FEDC2_CheQuiz_Gidong/pull/110/commits/3984e8b9fc4f1a6c5deefb7a362afc008426a30e)
- 기본 검색 및 정렬에 의한 필터링 구현 

[c79e57e](https://github.com/prgrms-fe-devcourse/FEDC2_CheQuiz_Gidong/pull/110/commits/c79e57e7dc4ac06281e9e9a6301d011609ddb2ad)
- 랜덤퀴즈를 담은 기본 채널은 메인페이지에서 출력 되지 않도록 변경

[b97ecfc](https://github.com/prgrms-fe-devcourse/FEDC2_CheQuiz_Gidong/pull/110/commits/b97ecfc5117e03e25db2a3e15074c0c39bdad220)
 - 검색 시 공백 제거 및 소문자로 변환하여 검색하도록 추가하였습니다.
## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 검색에 반영되어야 할 추가 사항 있다면 말씀해주세요 (description, 등..)
