### PR TITLE
[Feat] 퀴즈 상세보기 화면 구현 

### DIFF
--- a/src/components/Modal/QuizModal.tsx
+++ b/src/components/Modal/QuizModal.tsx
@@ -1,0 +1,69 @@
+import { UserQuizType } from '@/interfaces/UserAPI';
+import { getUserImageByPoints } from '@/utils/getUserImage';
+import * as S from './styles';
+
+interface Props {
+  quiz: UserQuizType;
+  isShown: boolean;
+  onClose: () => void;
+}
+
+function QuizModal({ quiz, isShown, onClose }: Props) {
+  return (
+    <>
+      {isShown && (
+        <S.Wrapper onClick={onClose}>
+          <S.Container onClick={(e) => e.stopPropagation()}>
+            <S.Title>퀴즈 자세히 보기</S.Title>
+            <S.SectionContainer>
+              <S.SectionTitle>질문</S.SectionTitle>
+              <S.Question>{quiz.question}</S.Question>
+            </S.SectionContainer>
+
+            <S.SectionContainer>
+              <S.SectionTitle>
+                정답 <span> {quiz.answer === 'true' ? 'O' : 'X'}</span>
+              </S.SectionTitle>
+              <S.Answer>{quiz.answerDescription}</S.Answer>
+            </S.SectionContainer>
+
+            {quiz.comments.length > 0 && (
+              <S.SectionContainer>
+                <S.SectionTitle>댓글</S.SectionTitle>
+                <S.CommentContainer>
+                  {quiz.comments.map((comment) => (
+                    <S.CommentItem key={comment._id}>
+                      <S.UserImage
+                        src={getUserImageByPoints(
+                          comment.author.username
+                            ? JSON.parse(comment.author.username).points
+                            : 0,
+                        )}
+                        alt="userImage"
+                      />
+                      <S.CommentContent>
+                        <S.CommentUsername>
+                          {comment.author.fullName}
+                        </S.CommentUsername>
+                        <S.CommentUsercomment>
+                          {comment.comment}
+                        </S.CommentUsercomment>
+                      </S.CommentContent>
+                    </S.CommentItem>
+                  ))}
+                </S.CommentContainer>
+              </S.SectionContainer>
+            )}
+
+            <S.ButtonContainer>
+              <S.CloseButton type="button">X</S.CloseButton>
+            </S.ButtonContainer>
+          </S.Container>
+        </S.Wrapper>
+      )}
+      {!isShown && null}
+    </>
+  );
+}
+
+export default QuizModal;

--- a/src/components/Modal/QuizModal.tsx
+++ b/src/components/Modal/QuizModal.tsx
@@ -56,7 +56,9 @@ function QuizModal({ quiz, isShown, onClose }: Props) {
             )}
 
             <S.ButtonContainer>
-              <S.CloseButton type="button">X</S.CloseButton>
+              <S.CloseButton type="button" onClick={onClose}>
+                X
+              </S.CloseButton>
             </S.ButtonContainer>
           </S.Container>
         </S.Wrapper>

--- a/src/components/Modal/styles.tsx
+++ b/src/components/Modal/styles.tsx
@@ -2,7 +2,11 @@ import styled from '@emotion/styled';
 import {
   borderRadius,
   DarkGray,
+  detail,
+  grayWhite,
   lightGrayWhite,
+  medium,
+  p,
   pointColor,
   small,
 } from '@/styles/theme';
@@ -22,6 +26,7 @@ export const Container = styled.div`
   width: 40rem;
   padding: 3rem;
   margin: auto;
+  position: relative;
 
   background-color: ${lightGrayWhite};
   border-radius: ${borderRadius};
@@ -68,4 +73,65 @@ export const ButtonInput = styled.input`
   border: 3px solid ${DarkGray};
   ${small};
   cursor: pointer;
+`;
+export const CloseButton = styled.button`
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  background-color: ${pointColor};
+  border-radius: ${borderRadius};
+  border: 3px solid ${DarkGray};
+  ${medium};
+  cursor: pointer;
+`;
+export const SectionContainer = styled.div`
+  padding: 0.5rem 0;
+`;
+export const SectionTitle = styled.h4`
+  font-size: 1rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+`;
+
+export const Question = styled.p`
+  font-family: Pretendard, sans-serif;
+  ${small}
+`;
+
+export const Answer = styled.div`
+  padding: 1rem;
+  background-color: ${grayWhite};
+  border-radius: 8px;
+  font-family: Pretendard, sans-serif;
+  ${detail}
+`;
+export const CommentItem = styled.div`
+  display: flex;
+`;
+
+export const UserImage = styled.img`
+  background-color: #dee2e6;
+  border-radius: 3px;
+  padding: 0.5rem;
+`;
+export const CommentContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding-left: 1rem;
+`;
+export const CommentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const CommentUsername = styled.span`
+  ${p}
+`;
+
+export const CommentUsercomment = styled.p`
+  ${detail}
 `;

--- a/src/components/UserInfo/UserInfoCard/styles.tsx
+++ b/src/components/UserInfo/UserInfoCard/styles.tsx
@@ -97,7 +97,6 @@ export const ExpCurrentContainer = styled(Card)`
 
 export const ExpDetail = styled.span`
   color: #495057;
-  z-index: 3;
   position: absolute;
   top: -1rem;
   right: 0px;

--- a/src/components/UserInfo/UserInfoTab/index.tsx
+++ b/src/components/UserInfo/UserInfoTab/index.tsx
@@ -10,8 +10,11 @@ function UserInfoTab({ id }: { id: string }) {
   const [madeQuizzes, setMadeQuizzes] = useState([]);
   const [commentedQuizzes, setCommentedQuizzes] = useState([]);
   const [likedQuizzes, setLikedQuizzes] = useState([]);
+  const [allQuizzes, setAllQuizzes] = useState([]);
 
   const [currentTab, setCurrentTab] = useState(0);
+
+  const [currentQuiz, setCurrentQuiz] = useState({});
 
   const tabMapper = [madeQuizzes, commentedQuizzes, likedQuizzes];
 
@@ -40,6 +43,7 @@ function UserInfoTab({ id }: { id: string }) {
         author: post.author,
         ...JSON.parse(post.title),
       }));
+      setAllQuizzes(realData);
 
       const userMadeQuizzes = realData.filter(
         (quiz: UserQuizType) => quiz.author._id === id,
@@ -58,6 +62,15 @@ function UserInfoTab({ id }: { id: string }) {
 
     updateAllQuiz();
   }, [id]);
+  const updateSelectedQuiz = (quizId: string) => {
+    const selectedQuiz = allQuizzes.find(
+      (quiz: UserQuizType) => quiz.id === quizId,
+    );
+    console.log(selectedQuiz);
+    if (selectedQuiz) {
+      setCurrentQuiz(selectedQuiz);
+    }
+  };
 
   const updateClickedTab = (tabId: number) => {
     setCurrentTab(tabId);
@@ -87,6 +100,7 @@ function UserInfoTab({ id }: { id: string }) {
               question={quiz.question}
               likeCount={quiz.likes.length}
               commentCount={quiz.comments.length}
+              handleClick={() => updateSelectedQuiz(quiz.id)}
             />
           ))}
         </S.UserQuizContainer>

--- a/src/components/UserInfo/UserInfoTab/index.tsx
+++ b/src/components/UserInfo/UserInfoTab/index.tsx
@@ -5,6 +5,7 @@ import { PostAPIUserInfo } from '@/interfaces/PostAPI';
 import { UserQuizType } from '@/interfaces/UserAPI';
 import UserQuizItem from '../UserQuizItem';
 import TabItem from '../UserInfoTabItem';
+import QuizModal from '@/components/Modal/QuizModal';
 
 function UserInfoTab({ id }: { id: string }) {
   const [madeQuizzes, setMadeQuizzes] = useState([]);
@@ -14,7 +15,8 @@ function UserInfoTab({ id }: { id: string }) {
 
   const [currentTab, setCurrentTab] = useState(0);
 
-  const [currentQuiz, setCurrentQuiz] = useState({});
+  const [currentQuiz, setCurrentQuiz] = useState({} as UserQuizType);
+  const [isModalShown, setIsModalShown] = useState(false);
 
   const tabMapper = [madeQuizzes, commentedQuizzes, likedQuizzes];
 
@@ -66,9 +68,9 @@ function UserInfoTab({ id }: { id: string }) {
     const selectedQuiz = allQuizzes.find(
       (quiz: UserQuizType) => quiz.id === quizId,
     );
-    console.log(selectedQuiz);
     if (selectedQuiz) {
       setCurrentQuiz(selectedQuiz);
+      setIsModalShown(true);
     }
   };
 
@@ -77,6 +79,11 @@ function UserInfoTab({ id }: { id: string }) {
   };
   return (
     <S.TabWrapper>
+      <QuizModal
+        quiz={currentQuiz}
+        isShown={isModalShown}
+        onClose={() => setIsModalShown(false)}
+      />
       <S.TabMenus>
         <S.TabItemContainer>
           {tabs.map((tab) => (

--- a/src/components/UserInfo/UserQuizItem/index.tsx
+++ b/src/components/UserInfo/UserQuizItem/index.tsx
@@ -5,6 +5,7 @@ interface QuizItemProps {
   question: string;
   likeCount: number;
   commentCount: number;
+  handleClick: () => void;
 }
 
 const IconProps = {
@@ -15,7 +16,12 @@ const IconProps = {
   rotate: 0,
 };
 
-function UserQuizItem({ question, likeCount, commentCount }: QuizItemProps) {
+function UserQuizItem({
+  question,
+  likeCount,
+  commentCount,
+  handleClick,
+}: QuizItemProps) {
   const renderCount = (currentCount: number, maxCount: number) => {
     if (currentCount > maxCount) {
       return `${maxCount}+`;
@@ -23,7 +29,7 @@ function UserQuizItem({ question, likeCount, commentCount }: QuizItemProps) {
     return `${currentCount}`;
   };
   return (
-    <S.ItemWrapper>
+    <S.ItemWrapper onClick={handleClick}>
       <S.ContentWrapper>
         <S.QuestionSymbol>Q.</S.QuestionSymbol>
         <S.QuestionText>{question}</S.QuestionText>


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 퀴즈 아이템 클릭 시 모달로 상세 내용이 뜨도록 구현하였습니다.
- 상세 퀴즈를 보여주면 좋을 것 같아 급한대로 이렇게 구현하였고, 추후 페이징 방식으로 옮길 예정입니다 ( 리팩토링)
![유저모달](https://user-images.githubusercontent.com/39826053/174707352-977e62dd-9e87-46f5-a887-f493bf6a3261.gif)

### 테스트 방법
1. http://localhost:3000/user/62ac0ca9377cfd03a86b5130  로 들어가서 각 퀴즈 누르면 모달 창이 뜨는지 확인해주세요!
2. /ranking + 유저 누르기나 /user/:userId로 원하는 유저의 정보에 들어거나, 퀴즈/댓글 추가 후 테스트해보셔도 좋습니다!
## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

> ea39a2406b6e609957a3a4e74011c4ee27b2ba6a 구현하다 보니 userCard 관련 style 오류가 보여 잠시 수정했습니다. ( z-index)

> 4068bdf9e9302eb0917d8a1c3c55dd755cbee307 선택한 퀴즈 정보를 state에 추가했습니다.

> 1185f83408568e185111641efe7e6417c79053f9 선택한 퀴즈를 모달창에 예쁘게 띄웠습니다.

> 8acb198324c7215ce5b2921137519ad4faeda07c 닫기 버튼 클릭시에도 모달창이 닫히도록 변경했습니다.

## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
-급하게 구현하느라 로직, 변수명 등이 부족한 면이 있습니다. 추후 리팩토링 예정이니 기능 동작 위주로 봐주시면 좋겠습니다.
혹시 동작이 잘 되지 않는다면 꼭 알려주세요

close #82 