### PR TITLE
[Fix] 랜덤 퀴즈 숫자 미선택시 SolvePage 뜨지 않는 오류

### DIFF
--- a/src/components/Home/RandomQuiz/index.tsx
+++ b/src/components/Home/RandomQuiz/index.tsx
@@ -1,20 +1,18 @@
+import React from 'react';
+import { useHistory } from 'react-router';
 import Select from '@/components/Form/Select';
 import { QUIZ_CATEGORY_LIST } from '@/constants';
 import { useQuizContext } from '@/contexts/QuizContext';
 import * as S from './styles';
 
 function RandomQuiz() {
-  const { setRandomQuizCount, setRandomQuizCategory, setChannelId } =
-    useQuizContext();
-
-  const handleQuizChange = (value: string) => {
-    setRandomQuizCount(Number(value));
-  };
-
-  const handleQuizStart = () => {
-    setChannelId(null);
-  };
-
+  const {
+    randomQuizCount,
+    setRandomQuizCount,
+    setRandomQuizCategory,
+    setChannelId,
+  } = useQuizContext();
+  const history = useHistory();
   const SelectStyle = {
     width: '7rem',
     color: '#555555',
@@ -24,6 +22,17 @@ function RandomQuiz() {
     appearance: 'auto',
     backgroundImage: 'none',
     backgroundColor: '#E9ECEF',
+  };
+
+  const handleQuizChange = (value: string) => {
+    setRandomQuizCount(Number(value));
+  };
+
+  const handleQuizStart = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    if (!randomQuizCount) return;
+    setChannelId(null);
+    history.push('/solve');
   };
 
   return (

--- a/src/pages/QuizSolvePage/index.tsx
+++ b/src/pages/QuizSolvePage/index.tsx
@@ -26,7 +26,8 @@ function QuizSolvePage() {
   const history = useHistory();
   const sliderRef = useRef<Slider | null>(null);
   const { user, setUser, isAuth } = useAuthContext();
-  const { channelId, randomQuizCount } = useQuizContext();
+  const { channelId, randomQuizCount, setChannelId, setRandomQuizCount } =
+    useQuizContext();
 
   const [quizzes, setQuizzes] = useState<QuizInterface[]>([]);
   const [userAnswers, setUserAnswers] = useState<string[]>([]);
@@ -84,9 +85,20 @@ function QuizSolvePage() {
         await updateUserPoint();
       }
 
+      setRandomQuizCount(null);
+      setChannelId(null);
+
       history.push('/result');
     },
-    [history, isAuth, quizzes, updateUserPoint, userAnswers],
+    [
+      history,
+      isAuth,
+      quizzes,
+      setChannelId,
+      setRandomQuizCount,
+      updateUserPoint,
+      userAnswers,
+    ],
   );
 
   // Slider Options
@@ -118,16 +130,14 @@ function QuizSolvePage() {
 
     (async () => {
       if (randomQuizCount && randomQuizCount > 0)
-        QuizServices.getShuffledQuizzes(randomQuizCount).then((quizArray) =>
-          next(quizArray),
+        await QuizServices.getShuffledQuizzes(randomQuizCount).then(
+          (quizArray) => next(quizArray),
         );
       else if (channelId)
-        QuizServices.getQuizzesFromChannel(channelId).then((quizArray) =>
+        await QuizServices.getQuizzesFromChannel(channelId).then((quizArray) =>
           next(quizArray),
         );
-    })();
-
-    setLoading(false);
+    })().finally(() => setLoading(false));
   }, [channelId, quizzes.length, randomQuizCount, setUserAnswers]);
 
   if (loading) return null;

--- a/src/pages/QuizSolvePage/index.tsx
+++ b/src/pages/QuizSolvePage/index.tsx
@@ -116,14 +116,18 @@ function QuizSolvePage() {
       setUserAnswers(Array(quizArray.length).fill(''));
     };
 
-    if (randomQuizCount && randomQuizCount > 0)
-      QuizServices.getShuffledQuizzes(randomQuizCount)
-        .then((quizArray) => next(quizArray))
-        .finally(() => setLoading(false));
-    else if (channelId)
-      QuizServices.getQuizzesFromChannel(channelId)
-        .then((quizArray) => next(quizArray))
-        .then(() => setLoading(false));
+    (async () => {
+      if (randomQuizCount && randomQuizCount > 0)
+        QuizServices.getShuffledQuizzes(randomQuizCount).then((quizArray) =>
+          next(quizArray),
+        );
+      else if (channelId)
+        QuizServices.getQuizzesFromChannel(channelId).then((quizArray) =>
+          next(quizArray),
+        );
+    })();
+
+    setLoading(false);
   }, [channelId, quizzes.length, randomQuizCount, setUserAnswers]);
 
   if (loading) return null;


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
-  메인 페이지에서 랜덤 퀴즈 개수를 선택하지 않고 Go 버튼을 누를 때 빈화면이 뜨는 현상을 수정하였습니다.
- **미해님이 리뷰주신 부분에 대하여 반영하였습니다.**

useState의 setState는 비동기적으로 값을 업데이트 하기 때문에 원래대로라면 setState(null) 처리 시 errorPage로 이동해야 하지만, submit 시에는 `history.push('/result')`를 통해 새로운 경로로 이동하기 때문에 errorpage로 이동하지 않습니다.


## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 4823378: randomQuizCount가 null 또는 0일때 Go 버튼이 눌러지지 않게 수정
- 05657a1: randomQuizCount와 channelId 모두 falsy 할 경우에도 에러페이지로 이동하도록 수정
- c9b1209: submit 후 context 값을 초기화 하도록 수정

## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 메인 페이지에서 랜덤 개수를 선택하지 않고 Go가 눌리는지 확인이 가능합니다.
- QuizSolvePage로 진입 후 다시 뒤로가기 -> 새로고침 -> 앞으로가기를 했을 때 에러페이지가 노출되는지 확인이 가능합니다.

close #146 