### PR TITLE
[Refactor] useQuiz hook 구현

### DIFF
--- a/src/api/QuizServices.ts
+++ b/src/api/QuizServices.ts
@@ -2,29 +2,11 @@ import axios from 'axios';
 
 import api from '@/api/axiosInstance';
 
+// ANCHOR: temporary import
 import type { QuizType } from '@/hooks/useQuiz/useQuiz.helper';
 import type { ChannelAPI } from '@/interfaces/ChannelAPI';
 import type { PostAPI } from '@/interfaces/PostAPI';
 import type { Quiz } from '@/interfaces/Quiz';
-
-function shuffle<T = unknown>(array: T[], count: number): T[] {
-  const ret = [...array];
-  for (let i = 0; i < array.length - 1; i += 1) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [ret[i], ret[j]] = [ret[j], ret[i]];
-  }
-  return ret.slice(0, count < ret.length ? count : ret.length);
-}
-
-function getPostIds() {
-  return api
-    .get<ChannelAPI[]>('/channels')
-    .then((response) => response.data)
-    .then((data) => data.flatMap((channel) => channel.posts))
-    .catch(() => {
-      throw new Error('error occured at getAllPostIds.');
-    });
-}
 
 function getPostsFromPostIds(postIds: string[]) {
   return axios.all(
@@ -48,10 +30,6 @@ export const getPosts = async () => {
   }
 };
 
-function getShuffledPosts(count: number) {
-  return getPosts().then((posts) => shuffle(posts, count));
-}
-
 function parseQuiz(post: PostAPI) {
   const postCopy: Partial<PostAPI> = { ...post };
   const quizContent = postCopy.title as string;
@@ -65,48 +43,12 @@ export function getPostsFromChannel(channelId: string): Promise<PostAPI[]> {
     .then((response) => response.data);
 }
 
-/**
- * @deprecated
- */
-export function getPostIdsFromChannel(channelName: string): Promise<string[]> {
-  return api
-    .get<ChannelAPI>(`/channels/${channelName}`)
-    .then((response) => response.data)
-    .then((data) => (data.posts ? data.posts : []))
-    .catch(() => {
-      throw new Error('error occured at getPostIdsFromChannel.');
-    });
-}
-
-/**
- * @deprecated
- */
-export function getShuffledPostIds(count: number) {
-  return getPostIds()
-    .then((postIds) => shuffle(postIds, count))
-    .catch(() => {
-      throw new Error('error occured at getShuffledPostIds.');
-    });
-}
-
 export function getQuizzesFromPostIds(postIds: string[]): Promise<Quiz[]> {
   return getPostsFromPostIds(postIds)
     .then((response) => response.map((post) => parseQuiz(post)))
     .catch(() => {
       throw new Error('error occured at getQuizzes');
     });
-}
-
-export function getQuizzesFromChannel(channelId: string) {
-  return getPostsFromChannel(channelId)
-    .then((posts) => posts.map((post) => parseQuiz(post)))
-    .then((quiz) => quiz.reverse());
-}
-
-export function getShuffledQuizzes(count: number) {
-  return getShuffledPosts(count).then((posts) =>
-    posts.map((post) => parseQuiz(post))
-  );
 }
 
 export function caculateScore(quizzes: QuizType[], userAnswers: string[]) {

--- a/src/api/QuizServices.ts
+++ b/src/api/QuizServices.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 import api from '@/api/axiosInstance';
 
+import type { QuizType } from '@/hooks/useQuiz/useQuiz.helper';
 import type { ChannelAPI } from '@/interfaces/ChannelAPI';
 import type { PostAPI } from '@/interfaces/PostAPI';
 import type { Quiz } from '@/interfaces/Quiz';
@@ -38,14 +39,14 @@ function getPostsFromPostIds(postIds: string[]) {
   );
 }
 
-function getPosts() {
-  return api
-    .get<PostAPI[]>('/posts')
-    .then((response) => response.data)
-    .catch(() => {
-      throw new Error('error occured at getPosts.');
-    });
-}
+export const getPosts = async () => {
+  try {
+    const response = await api.get<PostAPI[]>('/posts');
+    return response.data;
+  } catch (error) {
+    throw new Error('error occurred at getPosts.');
+  }
+};
 
 function getShuffledPosts(count: number) {
   return getPosts().then((posts) => shuffle(posts, count));
@@ -58,7 +59,7 @@ function parseQuiz(post: PostAPI) {
   return { ...postCopy, ...JSON.parse(quizContent) } as Quiz;
 }
 
-function getPostsFromChannel(channelId: string): Promise<PostAPI[]> {
+export function getPostsFromChannel(channelId: string): Promise<PostAPI[]> {
   return api
     .get<PostAPI[]>(`/posts/channel/${channelId}`)
     .then((response) => response.data);
@@ -108,7 +109,7 @@ export function getShuffledQuizzes(count: number) {
   );
 }
 
-export function caculateScore(quizzes: Quiz[], userAnswers: string[]) {
+export function caculateScore(quizzes: QuizType[], userAnswers: string[]) {
   // 전부 선택하지 않았거나 user가 임의로 조작했다면 0점을 부여한다.
   if (quizzes.length !== userAnswers.filter((answer) => answer).length)
     return 0;

--- a/src/api/QuizServices.ts
+++ b/src/api/QuizServices.ts
@@ -2,8 +2,6 @@ import axios from 'axios';
 
 import api from '@/api/axiosInstance';
 
-// ANCHOR: temporary import
-import type { QuizType } from '@/hooks/useQuiz/useQuiz.helper';
 import type { ChannelAPI } from '@/interfaces/ChannelAPI';
 import type { PostAPI } from '@/interfaces/PostAPI';
 import type { Quiz } from '@/interfaces/Quiz';
@@ -49,16 +47,6 @@ export function getQuizzesFromPostIds(postIds: string[]): Promise<Quiz[]> {
     .catch(() => {
       throw new Error('error occured at getQuizzes');
     });
-}
-
-export function caculateScore(quizzes: QuizType[], userAnswers: string[]) {
-  // 전부 선택하지 않았거나 user가 임의로 조작했다면 0점을 부여한다.
-  if (quizzes.length !== userAnswers.filter((answer) => answer).length)
-    return 0;
-  // filter corrected quizzes and add scores
-  return quizzes
-    .filter((quiz, index) => quiz.answer === userAnswers[index])
-    .reduce((acc, cur) => acc + cur.difficulty * 10, 0);
 }
 
 export async function getChannels() {

--- a/src/assets/QuizCreateMockData.ts
+++ b/src/assets/QuizCreateMockData.ts
@@ -1,4 +1,4 @@
-import { QuizClientContent } from '@/interfaces/Quiz';
+import type { QuizClientContent } from '@/interfaces/Quiz';
 
 const QUIZ_ITEM_DEFAULT_STATE: QuizClientContent = {
   _id: 0,

--- a/src/assets/QuizMockData.ts
+++ b/src/assets/QuizMockData.ts
@@ -1,4 +1,4 @@
-import { Quiz } from '@/interfaces/Quiz';
+import type { Quiz } from '@/interfaces/Quiz';
 
 const QuizMockData: Quiz[] = [
   {

--- a/src/assets/RankingMockData.ts
+++ b/src/assets/RankingMockData.ts
@@ -1,4 +1,4 @@
-import { UserAPI } from '@/interfaces/UserAPI';
+import type { UserAPI } from '@/interfaces/UserAPI';
 
 const RankingMockData: UserAPI[] = [
   {

--- a/src/assets/UserInfoMockData.ts
+++ b/src/assets/UserInfoMockData.ts
@@ -1,4 +1,4 @@
-import { UserAPI } from '@/interfaces/UserAPI';
+import type { UserAPI } from '@/interfaces/UserAPI';
 
 // API: GET /user/{userId}
 const UserInfoMockData: UserAPI = {

--- a/src/components/Form/Button/styles.ts
+++ b/src/components/Form/Button/styles.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @emotion/syntax-preference */
 import styled from '@emotion/styled';
 
 // TODO: 전역 스타일 컬러 적용

--- a/src/components/Home/QuizSetCard/styles.tsx
+++ b/src/components/Home/QuizSetCard/styles.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @emotion/syntax-preference */
 import styled from '@emotion/styled';
 
 import {

--- a/src/components/Quiz/index.tsx
+++ b/src/components/Quiz/index.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import * as S from './styles';
 
-import type { QuizType } from '@/hooks/useQuiz/useQuiz.helper';
+import type { Quiz as QuizType } from '@/hooks/useQuiz/useQuiz.helper';
 
 interface QuizProps {
   quiz: QuizType;

--- a/src/components/Quiz/index.tsx
+++ b/src/components/Quiz/index.tsx
@@ -2,10 +2,10 @@ import { useState } from 'react';
 
 import * as S from './styles';
 
-import type { Quiz as QuizInterface } from '@/interfaces/Quiz';
+import type { QuizType } from '@/hooks/useQuiz/useQuiz.helper';
 
 interface QuizProps {
-  quiz: QuizInterface;
+  quiz: QuizType;
   index: number;
   onChangeUserAnswer: (index: number, value: string) => void;
 }

--- a/src/components/UserInfo/UserInfoCard/styles.tsx
+++ b/src/components/UserInfo/UserInfoCard/styles.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @emotion/syntax-preference */
 import styled from '@emotion/styled';
 
 import { gray } from '@/styles/theme';

--- a/src/hooks/useQuiz/index.ts
+++ b/src/hooks/useQuiz/index.ts
@@ -1,0 +1,1 @@
+export { default as useQuiz } from './useQuiz';

--- a/src/hooks/useQuiz/useQuiz.helper.ts
+++ b/src/hooks/useQuiz/useQuiz.helper.ts
@@ -1,20 +1,18 @@
 import { getPostsFromChannel, getPosts } from '@/api/QuizServices';
 
 import type { PostAPI } from '@/interfaces/PostAPI';
-import type { Quiz, QuizContent } from '@/interfaces/Quiz';
+import type { QuizContent } from '@/interfaces/Quiz';
 
-// ANCHOR: 인터페이스에 변경 있을 경우 다시 확인할 것
-export type QuizType = Pick<
-  Quiz,
-  | '_id'
-  | 'question'
-  | 'answer'
-  | 'answerDescription'
-  | 'answerType'
-  | 'category'
-  | 'difficulty'
-  | 'importance'
->;
+export interface Quiz {
+  _id: string;
+  question: string;
+  answerDescription: string;
+  category: string;
+  difficulty: number;
+  importance: number;
+  answerType: 'trueOrFalse' | 'multipleChoice' | 'shortAnswer';
+  answer: string;
+}
 
 /**
  *
@@ -36,12 +34,18 @@ const shuffle = <T = unknown>(array: T[], count: number): T[] => {
 /**
  * Quiz 인터페이스를 구현하는 팩토리 함수
  */
-const createQuiz = (post: PostAPI): QuizType => {
+const createQuiz = (post: PostAPI): Quiz => {
   const quizContent = JSON.parse(post.title) as QuizContent;
 
   return {
     _id: post._id,
-    ...quizContent,
+    question: quizContent.question,
+    answerDescription: quizContent.answerDescription,
+    answer: quizContent.answer,
+    answerType: quizContent.answerType,
+    category: quizContent.category,
+    difficulty: quizContent.difficulty,
+    importance: quizContent.importance,
   };
 };
 

--- a/src/hooks/useQuiz/useQuiz.helper.ts
+++ b/src/hooks/useQuiz/useQuiz.helper.ts
@@ -1,0 +1,75 @@
+import { getPostsFromChannel, getPosts } from '@/api/QuizServices';
+
+import type { PostAPI } from '@/interfaces/PostAPI';
+import type { Quiz, QuizContent } from '@/interfaces/Quiz';
+
+// ANCHOR: 인터페이스에 변경 있을 경우 다시 확인할 것
+export type QuizType = Pick<
+  Quiz,
+  | '_id'
+  | 'question'
+  | 'answer'
+  | 'answerDescription'
+  | 'answerType'
+  | 'category'
+  | 'difficulty'
+  | 'importance'
+>;
+
+/**
+ *
+ * @param array 기존 소스로 사용되는 배열
+ * @param count 섞은 뒤 반환할 개수
+ * @returns 섞인 count의 길이를 갖는 배열
+ */
+const shuffle = <T = unknown>(array: T[], count: number): T[] => {
+  const ret = [...array];
+
+  for (let i = 0; i < array.length - 1; i += 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [ret[i], ret[j]] = [ret[j], ret[i]];
+  }
+
+  return ret.slice(0, count < ret.length ? count : ret.length);
+};
+
+/**
+ * Quiz 인터페이스를 구현하는 팩토리 함수
+ */
+const createQuiz = (post: PostAPI): QuizType => {
+  const quizContent = JSON.parse(post.title) as QuizContent;
+
+  return {
+    _id: post._id,
+    ...quizContent,
+  };
+};
+
+/**
+ * QuizSolve에 사용되는 quiz use cases
+ */
+class QuizService {
+  static async getShuffledQuizzes(count: number) {
+    try {
+      const posts = await getPosts();
+      const quizzes = posts.map((post) => createQuiz(post));
+
+      return shuffle(quizzes, count);
+    } catch (error) {
+      throw new Error('error occurred at QuizService.getShuffledQuizzes.');
+    }
+  }
+
+  static async getQuizzesFromQuizSet(channelId: string) {
+    try {
+      const posts = await getPostsFromChannel(channelId);
+      const quizzes = posts.map((post) => createQuiz(post)).reverse();
+
+      return quizzes;
+    } catch (error) {
+      throw new Error('error occurred at QuizService.getQuizzesFromQuizSet.');
+    }
+  }
+}
+
+export default QuizService;

--- a/src/hooks/useQuiz/useQuiz.helper.ts
+++ b/src/hooks/useQuiz/useQuiz.helper.ts
@@ -31,6 +31,16 @@ const shuffle = <T = unknown>(array: T[], count: number): T[] => {
   return ret.slice(0, count < ret.length ? count : ret.length);
 };
 
+export const calculateScore = (quizzes: Quiz[], userAnswers: string[]) => {
+  // 전부 선택하지 않았거나 user가 임의로 조작했다면 0점을 부여한다.
+  if (quizzes.length !== userAnswers.filter((answer) => answer).length)
+    return 0;
+  // filter corrected quizzes and add scores
+  return quizzes
+    .filter((quiz, index) => quiz.answer === userAnswers[index])
+    .reduce((acc, cur) => acc + cur.difficulty * 10, 0);
+};
+
 /**
  * Quiz 인터페이스를 구현하는 팩토리 함수
  */

--- a/src/hooks/useQuiz/useQuiz.ts
+++ b/src/hooks/useQuiz/useQuiz.ts
@@ -23,7 +23,7 @@ const useQuiz = (): ReturnType => {
     }
   }, []);
 
-  const getQuizzesfromQuizset = useCallback(async (channelId: string) => {
+  const getQuizzesFromQuizset = useCallback(async (channelId: string) => {
     try {
       const data = await QuizServices.getQuizzesFromChannel(channelId);
       setQuizzes(data);
@@ -32,7 +32,7 @@ const useQuiz = (): ReturnType => {
     }
   }, []);
 
-  return [quizzes, getRandomQuizzes, getQuizzesfromQuizset];
+  return [quizzes, getRandomQuizzes, getQuizzesFromQuizset];
 };
 
 export default useQuiz;

--- a/src/hooks/useQuiz/useQuiz.ts
+++ b/src/hooks/useQuiz/useQuiz.ts
@@ -2,16 +2,16 @@ import { useCallback, useState } from 'react';
 
 import QuizServices from './useQuiz.helper';
 
-import type { QuizType } from './useQuiz.helper';
+import type { Quiz } from './useQuiz.helper';
 
 type ReturnType = [
-  QuizType[],
+  Quiz[],
   (count: number) => Promise<void>,
   (channelId: string) => Promise<void>
 ];
 
 const useQuiz = (): ReturnType => {
-  const [quizzes, setQuizzes] = useState<QuizType[]>([]);
+  const [quizzes, setQuizzes] = useState<Quiz[]>([]);
 
   const getRandomQuizzes = useCallback(async (count: number) => {
     try {

--- a/src/hooks/useQuiz/useQuiz.ts
+++ b/src/hooks/useQuiz/useQuiz.ts
@@ -4,14 +4,8 @@ import * as QuizServices from '@/api/QuizServices';
 
 import type { Quiz as QuizInterface } from '@/interfaces/Quiz';
 
-type ReturnType = [
-  QuizInterface[],
-  (count: number) => Promise<void>,
-  (channelId: string) => Promise<void>
-];
-
 // ANCHOR: QuizResultPage 컨텐츠는 퀴즈보다는 Post의 성격이 강해서, 다른 hook에 넣을 예정
-const useQuiz = (): ReturnType => {
+const useQuiz = () => {
   const [quizzes, setQuizzes] = useState<QuizInterface[]>([]);
 
   const getRandomQuizzes = useCallback(async (count: number) => {
@@ -32,7 +26,21 @@ const useQuiz = (): ReturnType => {
     }
   }, []);
 
-  return [quizzes, getRandomQuizzes, getQuizzesFromQuizset];
+  const getQuizzesFromIds = useCallback(async (postIds: string[]) => {
+    try {
+      const data = await QuizServices.getQuizzesFromPostIds(postIds);
+      setQuizzes(data);
+    } catch (error) {
+      console.error(error);
+    }
+  }, []);
+
+  return {
+    quizzes,
+    getRandomQuizzes,
+    getQuizzesFromQuizset,
+    getQuizzesFromIds,
+  };
 };
 
 export default useQuiz;

--- a/src/hooks/useQuiz/useQuiz.ts
+++ b/src/hooks/useQuiz/useQuiz.ts
@@ -1,12 +1,19 @@
 import { useCallback, useState } from 'react';
 
-import * as QuizServices from '@/api/QuizServices';
+import QuizServices from './useQuiz.helper';
 
+import type { QuizType } from './useQuiz.helper';
 import type { Quiz as QuizInterface } from '@/interfaces/Quiz';
 
+type ReturnType = [
+  QuizType[],
+  (count: number) => Promise<void>,
+  (channelId: string) => Promise<void>
+];
+
 // ANCHOR: QuizResultPage 컨텐츠는 퀴즈보다는 Post의 성격이 강해서, 다른 hook에 넣을 예정
-const useQuiz = () => {
-  const [quizzes, setQuizzes] = useState<QuizInterface[]>([]);
+const useQuiz = (): ReturnType => {
+  const [quizzes, setQuizzes] = useState<QuizType[]>([]);
 
   const getRandomQuizzes = useCallback(async (count: number) => {
     try {
@@ -17,30 +24,16 @@ const useQuiz = () => {
     }
   }, []);
 
-  const getQuizzesFromQuizset = useCallback(async (channelId: string) => {
+  const getQuizzesFromQuizSet = useCallback(async (channelId: string) => {
     try {
-      const data = await QuizServices.getQuizzesFromChannel(channelId);
+      const data = await QuizServices.getQuizzesFromQuizSet(channelId);
       setQuizzes(data);
     } catch (error) {
       console.error(error);
     }
   }, []);
 
-  const getQuizzesFromIds = useCallback(async (postIds: string[]) => {
-    try {
-      const data = await QuizServices.getQuizzesFromPostIds(postIds);
-      setQuizzes(data);
-    } catch (error) {
-      console.error(error);
-    }
-  }, []);
-
-  return {
-    quizzes,
-    getRandomQuizzes,
-    getQuizzesFromQuizset,
-    getQuizzesFromIds,
-  };
+  return [quizzes, getRandomQuizzes, getQuizzesFromQuizSet];
 };
 
 export default useQuiz;

--- a/src/hooks/useQuiz/useQuiz.ts
+++ b/src/hooks/useQuiz/useQuiz.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState } from 'react';
+
+import * as QuizServices from '@/api/QuizServices';
+
+import type { Quiz as QuizInterface } from '@/interfaces/Quiz';
+
+type ReturnType = [
+  QuizInterface[],
+  (count: number) => Promise<void>,
+  (channelId: string) => Promise<void>
+];
+
+// ANCHOR: QuizResultPage 컨텐츠는 퀴즈보다는 Post의 성격이 강해서, 다른 hook에 넣을 예정
+const useQuiz = (): ReturnType => {
+  const [quizzes, setQuizzes] = useState<QuizInterface[]>([]);
+
+  const getRandomQuizzes = useCallback(async (count: number) => {
+    try {
+      const data = await QuizServices.getShuffledQuizzes(count);
+      setQuizzes(data);
+    } catch (error) {
+      console.error(error);
+    }
+  }, []);
+
+  const getQuizzesfromQuizset = useCallback(async (channelId: string) => {
+    try {
+      const data = await QuizServices.getQuizzesFromChannel(channelId);
+      setQuizzes(data);
+    } catch (error) {
+      console.error(error);
+    }
+  }, []);
+
+  return [quizzes, getRandomQuizzes, getQuizzesfromQuizset];
+};
+
+export default useQuiz;

--- a/src/hooks/useQuiz/useQuiz.ts
+++ b/src/hooks/useQuiz/useQuiz.ts
@@ -3,7 +3,6 @@ import { useCallback, useState } from 'react';
 import QuizServices from './useQuiz.helper';
 
 import type { QuizType } from './useQuiz.helper';
-import type { Quiz as QuizInterface } from '@/interfaces/Quiz';
 
 type ReturnType = [
   QuizType[],
@@ -11,7 +10,6 @@ type ReturnType = [
   (channelId: string) => Promise<void>
 ];
 
-// ANCHOR: QuizResultPage 컨텐츠는 퀴즈보다는 Post의 성격이 강해서, 다른 hook에 넣을 예정
 const useQuiz = (): ReturnType => {
   const [quizzes, setQuizzes] = useState<QuizType[]>([]);
 

--- a/src/hooks/useStorage/useLocalStorage.ts
+++ b/src/hooks/useStorage/useLocalStorage.ts
@@ -1,10 +1,12 @@
-import useStorage, { ReturnTypes } from './useStorage';
+import useStorage from './useStorage';
+
+import type { ReturnTypes } from './useStorage';
 
 function useLocalStorage<T>(key: string, defaultValue: T): ReturnTypes<T> {
   const [value, setItem, removeItem] = useStorage(
     key,
     defaultValue,
-    'localStorage',
+    'localStorage'
   );
 
   return [value, setItem, removeItem];

--- a/src/interfaces/CommentAPI.d.ts
+++ b/src/interfaces/CommentAPI.d.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-cycle
-import { UserAPI } from './UserAPI';
+import type { UserAPI } from './UserAPI';
 
 export interface CommentAPI {
   _id: string;

--- a/src/interfaces/NotificationAPI.d.ts
+++ b/src/interfaces/NotificationAPI.d.ts
@@ -1,6 +1,6 @@
-import { CommentAPI } from './CommentAPI';
-import { LikeAPI } from './LikeAPI';
-import { UserAPI } from './UserAPI';
+import type { CommentAPI } from './CommentAPI';
+import type { LikeAPI } from './LikeAPI';
+import type { UserAPI } from './UserAPI';
 
 export interface NotificationAPI {
   seen: boolean;

--- a/src/interfaces/PostAPI.d.ts
+++ b/src/interfaces/PostAPI.d.ts
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-cycle */
-import { ChannelAPI } from './ChannelAPI';
-import { CommentAPI } from './CommentAPI';
-import { LikeAPI } from './LikeAPI';
-import { UserAPI } from './UserAPI';
+import type { ChannelAPI } from './ChannelAPI';
+import type { CommentAPI } from './CommentAPI';
+import type { LikeAPI } from './LikeAPI';
+import type { UserAPI } from './UserAPI';
 /**
  * ANCHOR: title에는 stringify된 QuizContent interface 정보가 들어감
  * TODO: Like, Comment, Channel interface 추가

--- a/src/interfaces/Quiz.d.ts
+++ b/src/interfaces/Quiz.d.ts
@@ -1,4 +1,4 @@
-import { PostAPIBase } from './PostAPI';
+import type { PostAPIBase } from './PostAPI';
 
 export interface QuizContent {
   question: string;

--- a/src/interfaces/UserAPI.d.ts
+++ b/src/interfaces/UserAPI.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-cycle */
-import { CommentAPI } from './CommentAPI';
-import { PostAPI } from './PostAPI';
+import type { CommentAPI } from './CommentAPI';
+import type { PostAPI } from './PostAPI';
 
 export interface UserInfo {
   _id: string;

--- a/src/pages/QuizResultPage/index.tsx
+++ b/src/pages/QuizResultPage/index.tsx
@@ -1,16 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { Redirect } from 'react-router';
 
+import * as QuizServices from '@/api/QuizServices';
 import Header from '@/components/Header';
 import UserInfoCard from '@/components/UserInfo/UserInfoCard';
 import { POST_IDS, USER_ANSWERS } from '@/constants';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { useSessionStorage } from '@/hooks/useStorage';
 import QuizResult from '@components/QuizResult';
-import { useQuiz } from '@hooks/useQuiz';
 
 import * as S from './styles';
+
+import type { Quiz as QuizInterface } from '@/interfaces/Quiz';
 
 /**
  * ANCHOR: QuizResultPage 로직
@@ -21,7 +23,7 @@ import * as S from './styles';
  */
 const QuizResultPage = () => {
   const { user, isAuth } = useAuthContext();
-  const { quizzes, getQuizzesFromIds } = useQuiz();
+  const [quizzes, setQuizzes] = useState<QuizInterface[]>([]);
   const [postIds] = useSessionStorage<string[]>(POST_IDS, []);
   const [userAnswers] = useSessionStorage<string[]>(USER_ANSWERS, []);
   const [loading, setLoading] = useState(true);
@@ -33,6 +35,16 @@ const QuizResultPage = () => {
       return false;
     return true;
   };
+
+  // NOTE: 임시 콜백 함수입니다. QuizSolve가 정리된 후 해당 부분 처리 예정입니다.
+  const getQuizzesFromIds = useCallback(async (_postIds: string[]) => {
+    try {
+      const data = await QuizServices.getQuizzesFromPostIds(_postIds);
+      setQuizzes(data);
+    } catch (error) {
+      console.error(error);
+    }
+  }, []);
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/pages/QuizSolvePage/index.tsx
+++ b/src/pages/QuizSolvePage/index.tsx
@@ -28,7 +28,7 @@ const QuizSolvePage = () => {
   const { channelId, randomQuizCount, setChannelId, setRandomQuizCount } =
     useQuizContext();
 
-  const [quizzes, getRandomQuizzes, getQuizzesFromQuizset] = useQuiz();
+  const { quizzes, getRandomQuizzes, getQuizzesFromQuizset } = useQuiz();
   const [userAnswers, setUserAnswers] = useState<string[]>(Array(10).fill(''));
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);

--- a/src/pages/QuizSolvePage/index.tsx
+++ b/src/pages/QuizSolvePage/index.tsx
@@ -28,7 +28,7 @@ const QuizSolvePage = () => {
   const { channelId, randomQuizCount, setChannelId, setRandomQuizCount } =
     useQuizContext();
 
-  const { quizzes, getRandomQuizzes, getQuizzesFromQuizset } = useQuiz();
+  const [quizzes, getRandomQuizzes, getQuizzesFromQuizSet] = useQuiz();
   const [userAnswers, setUserAnswers] = useState<string[]>(Array(10).fill(''));
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -128,7 +128,7 @@ const QuizSolvePage = () => {
         if (randomQuizCount && randomQuizCount > 0) {
           await getRandomQuizzes(randomQuizCount);
         } else if (channelId) {
-          await getQuizzesFromQuizset(channelId);
+          await getQuizzesFromQuizSet(channelId);
         }
       } catch (error) {
         console.error(error);
@@ -141,7 +141,7 @@ const QuizSolvePage = () => {
     fetchData();
   }, [
     channelId,
-    getQuizzesFromQuizset,
+    getQuizzesFromQuizSet,
     getRandomQuizzes,
     randomQuizCount,
     setUserAnswers,

--- a/src/pages/QuizSolvePage/index.tsx
+++ b/src/pages/QuizSolvePage/index.tsx
@@ -7,7 +7,6 @@ import 'slick-carousel/slick/slick-theme.css';
 import 'slick-carousel/slick/slick.css';
 import { v4 } from 'uuid';
 
-import * as QuizServices from '@/api/QuizServices';
 import { updateTotalPoint } from '@/api/UserServices';
 import Icon from '@/components/Icon';
 import { POINTS, POST_IDS, USER_ANSWERS } from '@/constants';
@@ -15,6 +14,7 @@ import { useAuthContext } from '@/contexts/AuthContext';
 import { useQuizContext } from '@/contexts/QuizContext';
 import Quiz from '@components/Quiz';
 import { useQuiz } from '@hooks/useQuiz';
+import { calculateScore } from '@hooks/useQuiz/useQuiz.helper';
 
 import SliderButton from './SliderButton';
 import * as S from './styles';
@@ -41,7 +41,7 @@ const QuizSolvePage = () => {
 
   const updateUserPoint = useCallback(async () => {
     try {
-      const totalPoint = QuizServices.caculateScore(quizzes, userAnswers);
+      const totalPoint = calculateScore(quizzes, userAnswers);
       sessionStorage.setItem(POINTS, JSON.stringify(totalPoint));
 
       const newInfo = {


### PR DESCRIPTION
## 📌 PR 설명

<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

- useQuizHook을 구현하였습니다.
- useQuizHook을 구현하면서, api 도메인과 맞지 않는 함수들을 이동시켰습니다

**useQuiz hook**

useQuiz hook의 역할은 서버로부터 퀴즈 데이터를 받아와, 데이터를 useState로 정의된 자료 구조와 연결하는 역할을 합니다.

**useQuiz.helper**

useQuiz를 구현하면서, api 폴더에 위치하고 있는 퀴즈 관련 도메인을 해당 파일 내부로 이동시켰습니다. 최종 목표는 api 폴더 내부에는 서버에서 원시 데이터를 불러오는 순수 함수만 존재하도록 하는 것입니다.

useQuiz.helper로 이동한 함수는 다음과 같습니다.

- shuffle
- createQuiz (기존 parseQuiz와 다른 역할을 수행, 코멘트, 좋아요 등 퀴즈와 관련 없는 부분을 제거하고, 퀴즈만 만들어주는 팩토리 함수)
- QuizService 클래스 (퀴즈 관련 Use cases 구현 함수)

QuizSolvePage와 QuizResultPage의 사용 데이터가 달라, 해당 도메인을 분리하였습니다. QuizSolvePage: Quiz, QuizResultPage: Post

QuizService.ts의 파일명 변경은 이번 PR에서 변경하기에는 다소 변경점이 많은 것 같아 변경하지 않았습니다.

함수 선언형으로 작성된 문법을 함수 표현식으로 변경하였습니다.

## 💻 요구 사항과 구현 내용

<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- 550388e: useQuiz hook 구현
- 0c9b5c1: Quiz 도메인을 useQuiz로 이동시킴

## ✔️ PR 포인트 & 궁금한 점

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

### 질문

1. 현재 useQuiz.helper중 class로 QuizService로 묶은 이유는 해당 함수들이 유즈케이스와 관련이 있기 때문에, 추후 데이터 스키마 형태로 사용할 수 있을 것 같아서 설정한 것인데, 클래스 형식으로 두는 것이 별로일까요?
2. slack에서도 제안 드렸던 건데, 현재 API 스펙 변경이 빈번하게 일어나다보니, 좀 더 견고하게 해당 부분을 디자인해야할 필요성을 많이 느끼고 있습니다. [해당 문서](https://velog.io/@jjunyjjuny/%ED%94%84%EB%A1%A0%ED%8A%B8%EC%97%94%EB%93%9C-%EB%8D%B0%EC%9D%B4%ED%84%B0%EB%A5%BC-%EA%B0%80%EA%B3%B5%ED%95%98%EB%9D%BC) 방식으로 장기적으로 구성하면 어떨 지 궁금합니다. 물론 혼자서는 힘들 것 같고, 여러분들의 합의가 있어야만 가능할 듯 싶습니다.

### 제안합니다

현재 `@typescript-eslint/requiring-type-checking` rule을 사용하고 있는데, 여기서 `@typescript-eslint/no-floating-promises` rule이 자꾸 문제를 일으킵니다. useEffect의 callback 함수로는 `Promise<void>` 형태의 return type이 올 수 없는데(즉 async await형식으로 사용이 불가능한데), 실제 useEffect 내에서 async function을 정의하고, 바로 호출하는 형태로 사용하고 있어서 해당 부분마다 문제를 일으킵니다.

```tsx
useEffect(() => {

    const fetchData = async () => {
      try {
        if (randomQuizCount && randomQuizCount > 0) {
          await getRandomQuizzes(randomQuizCount);
        } else if (channelId) {
          await getQuizzesFromQuizSet(channelId);
        }
      } catch (error) {
        console.error(error);
      } finally {
        setLoading(false);
      }
    };

    // floating-promises error 발생
    fetchData();
  }, []);
```

해당 eslint 옵션을 off설정하는 것을 제안합니다. 끄지 않고 사용할 수 있는 다른 방법이 있다면, 알려주시면 감사하겠습니다.

close #169 
