### PR TITLE
[Refactor] (v1) QuizSolvePage 로직 리팩토링

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -70,6 +70,7 @@
     "import/prefer-default-export": "off",
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/no-static-element-interactions": "off",
+    "no-console": ["warn", { "allow": ["warn", "error"] }],
     "no-underscore-dangle": "off",
     "react/function-component-definition": [
       "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -70,7 +70,6 @@
     "import/prefer-default-export": "off",
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/no-static-element-interactions": "off",
-    "no-console": ["warn", { "allow": ["warn", "error"] }],
     "no-underscore-dangle": "off",
     "react/function-component-definition": [
       "error",

--- a/src/hooks/shared/useLoading/index.ts
+++ b/src/hooks/shared/useLoading/index.ts
@@ -1,0 +1,3 @@
+import useLoading from './useLoading';
+
+export default useLoading;

--- a/src/hooks/shared/useLoading/useLoading.ts
+++ b/src/hooks/shared/useLoading/useLoading.ts
@@ -1,0 +1,24 @@
+import { useCallback, useState } from 'react';
+
+const useLoading: (
+  initialValue?: boolean
+) => [boolean, <T>(promise: Promise<T>) => Promise<T>] = (
+  initialValue = false
+) => {
+  const [isLoading, setIsLoading] = useState(initialValue);
+
+  const startTransition = useCallback(async <T>(promise: Promise<T>) => {
+    try {
+      setIsLoading(true);
+      const data = await promise;
+
+      return data;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return [isLoading, startTransition];
+};
+
+export default useLoading;

--- a/src/hooks/useQuiz/index.ts
+++ b/src/hooks/useQuiz/index.ts
@@ -1,0 +1,3 @@
+import useQuiz from './useQuiz';
+
+export default useQuiz;

--- a/src/hooks/useQuiz/useQuiz.ts
+++ b/src/hooks/useQuiz/useQuiz.ts
@@ -14,7 +14,7 @@ const useQuiz = () => {
     );
   }, []);
 
-  const getRandomQuizzes = useCallback(async (count: number) => {
+  const getQuizRandom = useCallback(async (count: number) => {
     try {
       const randomQuizzes = await getShuffledQuizzes(count);
 
@@ -26,7 +26,7 @@ const useQuiz = () => {
     }
   }, []);
 
-  const getSetQuizzes = useCallback(async (channel: string) => {
+  const getQuizSet = useCallback(async (channel: string) => {
     try {
       const quizSet = await getQuizzesFromChannel(channel);
 
@@ -42,8 +42,8 @@ const useQuiz = () => {
     quizzes,
     userAnswers,
     handleUserAnswers,
-    getRandomQuizzes,
-    getSetQuizzes,
+    getQuizRandom,
+    getQuizSet,
   };
 };
 

--- a/src/hooks/useQuiz/useQuiz.ts
+++ b/src/hooks/useQuiz/useQuiz.ts
@@ -1,0 +1,50 @@
+import { useState, useCallback } from 'react';
+
+import { getShuffledQuizzes, getQuizzesFromChannel } from '@/api/QuizServices';
+
+import type { Quiz as QuizInterface } from '@/interfaces/Quiz';
+
+const useQuiz = () => {
+  const [quizzes, setQuizzes] = useState<QuizInterface[]>([]);
+  const [userAnswers, setUserAnswers] = useState<string[]>([]);
+
+  const handleUserAnswers = useCallback((index: number, value: string) => {
+    setUserAnswers((prev) =>
+      prev.map((answer, idx) => (idx === index ? value : answer))
+    );
+  }, []);
+
+  const getRandomQuizzes = useCallback(async (count: number) => {
+    try {
+      const randomQuizzes = await getShuffledQuizzes(count);
+
+      setQuizzes(randomQuizzes);
+      setUserAnswers(Array(randomQuizzes.length).fill(''));
+    } catch (error) {
+      console.error('error occurred at getRandomQuizzes.');
+      console.error(error);
+    }
+  }, []);
+
+  const getSetQuizzes = useCallback(async (channel: string) => {
+    try {
+      const quizSet = await getQuizzesFromChannel(channel);
+
+      setQuizzes(quizSet);
+      setUserAnswers(Array(quizSet.length).fill(''));
+    } catch (error) {
+      console.error('error occurred at getSetQuizzes.');
+      console.error(error);
+    }
+  }, []);
+
+  return {
+    quizzes,
+    userAnswers,
+    handleUserAnswers,
+    getRandomQuizzes,
+    getSetQuizzes,
+  };
+};
+
+export default useQuiz;

--- a/src/interfaces/UserAPI.d.ts
+++ b/src/interfaces/UserAPI.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-cycle */
-import { CommentAPI } from './CommentAPI';
-import { PostAPI } from './PostAPI';
+import type { CommentAPI } from './CommentAPI';
+import type { PostAPI } from './PostAPI';
 
 export interface UserInfo {
   _id: string;

--- a/src/pages/QuizSolvePage/QuizSolvePage.helper.ts
+++ b/src/pages/QuizSolvePage/QuizSolvePage.helper.ts
@@ -1,6 +1,6 @@
 import { v4 } from 'uuid';
 
-import { updateTotalPoint } from '@/api/UserServices';
+import { updateTotalPoint as updateUserScore } from '@/api/UserServices';
 import { POINTS } from '@/constants';
 
 import type { UserAPI, UserQuizInfo } from '@/interfaces/UserAPI';
@@ -12,7 +12,7 @@ import type { UserAPI, UserQuizInfo } from '@/interfaces/UserAPI';
  * @param point 이번 퀴즈를 해결해서 얻은 점수
  * @returns UserQuizInfo 객체
  */
-export const getNextQuizInfoOf = (user: UserAPI, point: number) => {
+export const getUserScore = (user: UserAPI, point: number) => {
   // 유저가 처음 문제를 해결하면 정보가 없기 때문에, 이를 반환하는 객체가 필요하다.
   const newInfo: UserQuizInfo = {
     _id: v4(),
@@ -36,9 +36,9 @@ export const updateUserPoint = async (user: UserAPI, totalPoint: number) => {
     sessionStorage.setItem(POINTS, JSON.stringify(totalPoint));
 
     // user 정보 업데이트
-    const newUserInfo = await updateTotalPoint({
+    const newUserInfo = await updateUserScore({
       fullName: user.fullName,
-      username: getNextQuizInfoOf(user, totalPoint),
+      username: getUserScore(user, totalPoint),
     });
 
     return newUserInfo;

--- a/src/pages/QuizSolvePage/QuizSolvePage.helper.ts
+++ b/src/pages/QuizSolvePage/QuizSolvePage.helper.ts
@@ -1,0 +1,48 @@
+import { v4 } from 'uuid';
+
+import { updateTotalPoint } from '@/api/UserServices';
+import { POINTS } from '@/constants';
+
+import type { UserAPI, UserQuizInfo } from '@/interfaces/UserAPI';
+
+/**
+ * @description
+ * userQuizInfo를 반환하는 QuizSolvePage의 helper 함수입니다.
+ * @param user UserAPI 인터페이스를 갖는 유저 정보
+ * @param point 이번 퀴즈를 해결해서 얻은 점수
+ * @returns UserQuizInfo 객체
+ */
+export const getNextQuizInfoOf = (user: UserAPI, point: number) => {
+  // 유저가 처음 문제를 해결하면 정보가 없기 때문에, 이를 반환하는 객체가 필요하다.
+  const newInfo: UserQuizInfo = {
+    _id: v4(),
+    points: point,
+  };
+
+  if (user.username) {
+    const prevUserInfo = JSON.parse(user.username) as Partial<UserQuizInfo>;
+
+    if (prevUserInfo._id) newInfo._id = prevUserInfo._id;
+
+    if (prevUserInfo.points) newInfo.points = point + prevUserInfo.points;
+  }
+
+  return newInfo;
+};
+
+// totalPoint를 받아와 이를 서버에 반영한다.
+export const updateUserPoint = async (user: UserAPI, totalPoint: number) => {
+  try {
+    sessionStorage.setItem(POINTS, JSON.stringify(totalPoint));
+
+    // user 정보 업데이트
+    const newUserInfo = await updateTotalPoint({
+      fullName: user.fullName,
+      username: getNextQuizInfoOf(user, totalPoint),
+    });
+
+    return newUserInfo;
+  } catch {
+    throw new Error('error occurred at updateUserPoint.');
+  }
+};

--- a/src/pages/QuizSolvePage/QuizSolvePage.tsx
+++ b/src/pages/QuizSolvePage/QuizSolvePage.tsx
@@ -32,30 +32,44 @@ const QuizSolvePage = () => {
     );
   }, []);
 
-  const updateUserPoint = useCallback(async () => {
-    try {
-      const totalPoint = QuizServices.caculateScore(quizzes, userAnswers);
-      sessionStorage.setItem(POINTS, JSON.stringify(totalPoint));
-
-      const newInfo = {
+  // totalPoint를 받아와 이를 서버에 반영한다.
+  const updateUserPoint = async (totalPoint: number) => {
+    const getNewUserQuizInfo = () => {
+      // userInfo에 들어갈 임시 데이터
+      const newInfo: UserQuizInfo = {
         _id: v4(),
         points: totalPoint,
       };
+
       if (user.username) {
-        const prevUserInfo = JSON.parse(user.username) as UserQuizInfo;
+        const prevUserInfo = JSON.parse(user.username) as Partial<UserQuizInfo>;
+
         if (prevUserInfo._id) newInfo._id = prevUserInfo._id;
+
         if (prevUserInfo.points)
           newInfo.points = totalPoint + prevUserInfo.points;
       }
+
+      return newInfo;
+    };
+
+    try {
+      sessionStorage.setItem(POINTS, JSON.stringify(totalPoint));
+
+      // user의 퀴즈 정보가 username에 저장되어 있기 때문에, user.username을 호출한다.
+      // 첫 호출시에는 없을 수 있기 때문에 확인해야 한다.
+
+      // user 정보 업데이트
       const newUserInfo = await updateTotalPoint({
         fullName: user.fullName,
-        username: newInfo,
+        username: getNewUserQuizInfo(),
       });
+
       setUser(newUserInfo);
     } catch {
       throw new Error('error occurred at updateUserPoint.');
     }
-  }, [quizzes, setUser, user.fullName, user.username, userAnswers]);
+  };
 
   const validate = () => {
     if (quizzes.length !== userAnswers.filter((answer) => answer).length)
@@ -85,10 +99,13 @@ const QuizSolvePage = () => {
       return;
     }
 
+    // 점수 계산
+    const totalPoint = QuizServices.caculateScore(quizzes, userAnswers);
+
     // 로그인했다면, 사용자의 점수를 반영
     if (isAuth) {
       try {
-        await updateUserPoint();
+        await updateUserPoint(totalPoint);
       } catch (error) {
         console.error(error);
       }

--- a/src/pages/QuizSolvePage/QuizSolvePage.tsx
+++ b/src/pages/QuizSolvePage/QuizSolvePage.tsx
@@ -20,13 +20,8 @@ const QuizSolvePage = () => {
   const { channelId, randomQuizCount, setChannelId, setRandomQuizCount } =
     useQuizContext();
 
-  const {
-    quizzes,
-    userAnswers,
-    handleUserAnswers,
-    getSetQuizzes,
-    getRandomQuizzes,
-  } = useQuiz();
+  const { quizzes, userAnswers, handleUserAnswers, getQuizSet, getQuizRandom } =
+    useQuiz();
 
   const [isLoading, startTransition] = useLoading(true);
 
@@ -91,9 +86,9 @@ const QuizSolvePage = () => {
       (async () => {
         try {
           if (randomQuizCount && randomQuizCount > 0) {
-            await getRandomQuizzes(randomQuizCount);
+            await getQuizRandom(randomQuizCount);
           } else if (channelId) {
-            await getSetQuizzes(channelId);
+            await getQuizSet(channelId);
           }
         } catch (error) {
           console.error('error occurred at QuizSolvePage.');
@@ -101,13 +96,7 @@ const QuizSolvePage = () => {
         }
       })()
     );
-  }, [
-    channelId,
-    getRandomQuizzes,
-    getSetQuizzes,
-    randomQuizCount,
-    startTransition,
-  ]);
+  }, [channelId, getQuizRandom, getQuizSet, randomQuizCount, startTransition]);
 
   const disabled =
     userAnswers.filter((answer) => answer).length < quizzes.length;


### PR DESCRIPTION
<!--
# PR 체크리스트

### PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [ ] PR 우측 Labels에서 적절한 라벨을 부착하였습니다.
- [ ] Commit 메세지 규칙에 맞게 작성했습니다.
- [ ] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능에대한 오류가 없는것을 확인했습니다
- [ ] 브라우저 콘솔상 에러가 없는것을 확인했습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인했습니다
- [ ] 코드 리뷰 사항을 모두 반영하였습니다.
- [ ] 리뷰어에 1명 할당했습니다.
-->

## 📌 PR 설명
<!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
QuizSolvePage의 로직 리팩토링입니다.
로직 리팩토링은 다음의 기준을 갖고 작업했습니다.

1. 추후 QuizSolvePage와 QuizResultPage에서 공통적으로 사용될 수 있는 데이터인 퀴즈 데이터와 userAnswer 정보들을 useQuiz hook으로 묶었습니다.
2. QuizSolvePage의 가장 윗쪽은 데이터를 배치하고, 중간에는 이벤트를 배치하고, 아래에는 UI를 배치하는 형태로 작성을 했습니다.

나머지 부분은 커밋을 따라가면서 보시면 편하실 것이라 생각합니다.

## 💻 요구 사항과 구현 내용
<!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
[[feat] useLoading hook 구현](https://github.com/prgrms-fe-devcourse/FEDC2_CheQuiz_Gidong/commit/d56e57b4106b4113f3ec1e8a360d7082fcc184ad)
- useLoading hook을 구현했습니다. 구현 방법은 toss/slash 를 참고하였습니다. (사실상 동일합니다)


## ✔️ PR 포인트 & 궁금한 점
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
1. useQuiz 데이터 범위가 적절한지 여쭤보고 싶습니다. 현재는 quiz 데이터와 user answers 데이터, 그리고 이것들을 다루는 메서드들로 구현을 했는데, user score를 여기에 추가해도 될까 고민중에 있습니다. score 관련 부분은 result page에서 사용되는 부분이라 추후 공통적으로 사용될 경우 묶을 수 있을 것 같은데, QuizSolvePage에서는 스코어를 계산만 하고 실제로 스코어 데이터가 사용되는 부분은 없습니다.
2. QuizSolvePage의 helper 함수 위치 - 현재는 QuizSolvePage.helper.ts 함수에 위치를 시켜놓았는데, helper가 로직 위주의 함수들로 구성이 되어있다보니 QuizSolvePage와 함께 위치시켜야 할 지, 아니면 다른 쪽으로 빼는 것이 어떨 지 고민입니다. 만약 스코어 데이터를 useQuiz hook에 편입시킨다면, useQuiz helper에 위치시키면 해결 될 문제이기도 합니다.
3. QuizSolvePage에서 `validate` 함수가 에러를 던지고 있는데, 에러를 던지는 것과 true or false 형식으로 validation을 진행하는 것 중, 어떤 방법이 정석적인 패턴?(이란 게 있나 모르겠지만)일까요?

당장 반영할 수 있는 부분은 반영하여 머지하겠습니다. 다만, 현재로서 고려하지 않아도 될 법한 (QuizResultPage를 고려한 데이터 합침) 등은 현재로서는 오버 엔지니어링이라고 생각해서, 반영 후 추후 고도화를 진행하도록 하겠습니다.

close #184 
